### PR TITLE
sdcadm#13 Use of xargs with sdc-server lookup is superfluous

### DIFF
--- a/lib/cli/do_update_agents.js
+++ b/lib/cli/do_update_agents.js
@@ -79,11 +79,11 @@ do_update_agents.help = (
     '\n' +
     '    # Update a specific agentsshar on setup servers with the "pkg=aegean" trait.\n' +
     '    {{name}} update-agents 8198c6c0-778c-11e5-8416-13cb06970b44 \\\n' +
-    '        $(sdc-server lookup setup=true traits.pkg=aegean | xargs)\n' +
+    '        $(sdc-server lookup setup=true traits.pkg=aegean)\n' +
     '\n' +
     '    # Update on setup servers, excluding those with a "internal=PKGSRC" trait.\n' +
     '    {{name}} update-agents 8198c6c0-778c-11e5-8416-13cb06970b44 \\\n' +
-    '        $(sdc-server lookup setup=true \'traits.internal!~PKGSRC\' | xargs)\n'
+    '        $(sdc-server lookup setup=true \'traits.internal!~PKGSRC\')\n'
     /* END JSSTYLED */
 );
 do_update_agents.options = [

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1685,11 +1685,11 @@ PlatformCLI.prototype.do_assign.help = (
     '\n' +
     '    # Assign a specific platform  on setup servers with the "pkg=aegean" trait.\n' +
     '    {{name}} assign 20151021T183753Z \\\n' +
-    '        $(sdc-server lookup setup=true traits.pkg=aegean | xargs)\n' +
+    '        $(sdc-server lookup setup=true traits.pkg=aegean)\n' +
     '\n' +
     '    # Assign a platform, excluding those with a "internal=PKGSRC" trait.\n' +
     '    {{name}} assign 20151021T183753Z \\\n' +
-    '        $(sdc-server lookup setup=true \'traits.internal!~PKGSRC\' | xargs)\n'
+    '        $(sdc-server lookup setup=true \'traits.internal!~PKGSRC\')\n'
     /* END JSSTYLED */
 
 );

--- a/man/man1/sdcadm.1.ronn
+++ b/man/man1/sdcadm.1.ronn
@@ -556,11 +556,11 @@ Examples:
 
     # Assign a specific platform  on setup servers with the "pkg=aegean" trait.
     sdcadm platform update-agents 20151021T183753Z \
-        $(sdc-server lookup setup=true traits.pkg=aegean | xargs)
+        $(sdc-server lookup setup=true traits.pkg=aegean)
 
     # Assign a platform, excluding those with a "internal=PKGSRC" trait.
     sdcadm platform update-agents 20151021T183753Z \
-        $(sdc-server lookup setup=true 'traits.internal!~PKGSRC' | xargs)
+        $(sdc-server lookup setup=true 'traits.internal!~PKGSRC')
 
 
 ### sdcadm platform list \[options\]
@@ -935,11 +935,11 @@ Examples:
 
     # Update a specific agentsshar on setup servers with the "pkg=aegean" trait.
     sdcadm experimental update-agents 8198c6c0-778c-11e5-8416-13cb06970b44 \
-        $(sdc-server lookup setup=true traits.pkg=aegean | xargs)
+        $(sdc-server lookup setup=true traits.pkg=aegean)
 
     # Update on setup servers, excluding those with a "internal=PKGSRC" trait.
     sdcadm experimental update-agents 8198c6c0-778c-11e5-8416-13cb06970b44 \
-        $(sdc-server lookup setup=true 'traits.internal!~PKGSRC' | xargs)
+        $(sdc-server lookup setup=true 'traits.internal!~PKGSRC')
 
 ### sdcadm experimental update-other
 


### PR DESCRIPTION
should be stricken from documentation.