### PR TITLE
TOOLS-1421: `sdcadm experimental volapi` to setup Volumes API service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 # sdcadm Changelog
 
-## 1.11.3
+## 1.12.0
 
 -  TOOLS-1421: `sdcadm experimental volapi` to setup Volumes API service
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 
 # sdcadm Changelog
 
+## 1.11.3
+
+-  TOOLS-1421: `sdcadm experimental volapi` to setup Volumes API service
+
 ## 1.11.1
 
 - TOOLS-1380: 'sdcadm insts' (and other code paths) crash on gather dockerlogger instance info

--- a/etc/defaults.json
+++ b/etc/defaults.json
@@ -42,7 +42,8 @@
         "vm-agent": "vm-agent",
         "net-agent": "net-agent",
         "config-agent": "config-agent",
-        "dockerlogger": "dockerlogger"
+        "dockerlogger": "dockerlogger",
+        "volapi": "volapi"
     },
     "svcMinImages": {
         "binder": "20140731T211135Z",

--- a/lib/cli/do_update_other.js
+++ b/lib/cli/do_update_other.js
@@ -30,7 +30,7 @@ var steps = require('../steps');
  * will check them during update-other and add their metadata if
  * we need to.
  */
-var NEW_SERVICES = ['papi', 'mahi', 'cns', 'portolan', 'docker'];
+var NEW_SERVICES = ['papi', 'mahi', 'cns', 'portolan', 'docker', 'volapi'];
 
 /*
  * The 'sdcadm experimental update-other' CLI subcommand.

--- a/lib/cli/do_volapi.js
+++ b/lib/cli/do_volapi.js
@@ -23,7 +23,7 @@ var DownloadImages = require('../procedures/download-images').DownloadImages;
 var shared = require('../procedures/shared');
 
 var NB_MBS_IN_GB = 1024;
-var NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX = 'nfs_shared_volume_';
+var NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX = 'sdc_volume_nfs';
 // Sizes are in GBs
 var NFS_SHARED_VOLUMES_PKG_SIZES = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
     200, 300, 400, 500, 600, 700, 800, 900, 1000];
@@ -59,19 +59,111 @@ function addSharedVolumePackage(cli, packageSettings, callback) {
 
     var papiClient = cli.sdcadm.papi;
 
-    var packageName = NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX
-        + packageSettings.size;
-    cli.progress(util.format('Creating "%s" package', packageName));
+    var packageName = [
+        NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX,
+        packageSettings.size
+    ].join('_');
 
-    var newPackage = {
-        name: packageName,
-        quota: packageSettings.size * NB_MBS_IN_GB,
-        owner_uuids: packageSettings.owner_uuids
+    var context = {
+        foundPackage: false
     };
 
-    common.objCopy(NFS_SHARED_VOLUMES_PACKAGE_TEMPLATE, newPackage);
+    vasync.pipeline({
+        funcs: [
+            function _findPackage(ctx, next) {
+                papiClient.list({name: packageName}, {},
+                    function onPackagesListed(err, pkgs) {
+                        if (!err && pkgs && pkgs.length > 0) {
+                            ctx.foundPackage = true;
+                        }
 
-    papiClient.add(newPackage, callback);
+                        next(err);
+                    });
+            },
+            function _addPackage(ctx, next) {
+                if (ctx.foundPackage) {
+                    next();
+                    return;
+                }
+
+                var newPackage = {
+                    name: packageName,
+                    quota: packageSettings.size * NB_MBS_IN_GB,
+                    owner_uuids: packageSettings.owner_uuids
+                };
+
+                common.objCopy(NFS_SHARED_VOLUMES_PACKAGE_TEMPLATE, newPackage);
+                cli.log.info({pkg: newPackage}, 'Adding package');
+
+                papiClient.add(newPackage, function onPackageAdded(err, pkg) {
+                    if (!err && pkg) {
+                        ctx.pkgAdded = pkg;
+                        cli.log.info({package: pkg}, 'Package added');
+                    }
+
+                    next(err);
+                });
+            }
+        ],
+        arg: context
+    }, function _addSharedVolumePackageDone(err) {
+        callback(err, context.pkgAdded);
+    });
+}
+
+function enableNfsSharedVolumesInDocker(dockerSvcId, options, callback) {
+    assert.string(dockerSvcId, 'dockerSvcId');
+    assert.object(options, 'options');
+    assert.object(options.sapiClient, 'options.sapiClient');
+    assert.func(callback, 'callback');
+
+    var sapiClient = options.sapiClient;
+    var context = {
+        nfsSharedVolumesAlreadyEnabled: false,
+        didEnableNfsSharedVolumes: false
+    };
+
+    vasync.pipeline({
+        funcs: [
+            function _checkAlreadyEnabled(ctx, next) {
+                sapiClient.getService(dockerSvcId,
+                    function _onGetDockerSvc(err, dockerSvc) {
+                        var dockerSvcMetadata;
+                        if (dockerSvc) {
+                            dockerSvcMetadata = dockerSvc.metadata;
+                        }
+
+                        if (dockerSvcMetadata.experimental_nfs_shared_volumes) {
+                            ctx.nfsSharedVolumesAlreadyEnabled = true;
+                        }
+
+                        next(err);
+                    });
+            },
+            function _enableNfsSharedVolumes(ctx, next) {
+                if (ctx.nfsSharedVolumesAlreadyEnabled) {
+                    next();
+                    return;
+                }
+
+                sapiClient.updateService(dockerSvcId, {
+                    action: 'update',
+                    metadata: {
+                        experimental_nfs_shared_volumes: true
+                    }
+                }, function onDockerSvcUpdated(err) {
+                    if (!err) {
+                        ctx.didEnableNfsSharedVolumes = true;
+                    }
+
+                    next(err);
+                });
+            }
+        ],
+        arg: context
+    }, function _updateDockerServiceDone(err) {
+        callback(err, context.didEnableNfsSharedVolumes);
+    });
 }
 
 function do_volapi(subcmd, opts, args, cb) {
@@ -314,17 +406,29 @@ function do_volapi(subcmd, opts, args, cb) {
             var packagesSettings =
                 NFS_SHARED_VOLUMES_PKG_SIZES.map(createPackageSettings);
 
-            self.progress('Adding NFS shared volume packages');
-            ctx.didSomething = true;
-
             vasync.forEachParallel({
                 func: addSharedVolumePackage.bind(null, self),
                 inputs: packagesSettings
-            }, function sharedVolumesPackagesAdded(err) {
+            }, function sharedVolumesPackagesAdded(err, results) {
                 if (err) {
-                    console.error(util.inspect(err, {depth:null}));
+                    self.log.error({error: err}, 'Error when adding packages');
                 }
-                self.progress('NFS shared volume packages added');
+
+                var addedPackageNames = [];
+
+                results.operations.forEach(function addPkgName(operation) {
+                    if (operation.result) {
+                        addedPackageNames.push(operation.result.name);
+                    }
+                });
+
+                if (addedPackageNames.length > 0) {
+                    self.progress('Added NFS shared volumes packages:\n'
+                        + addedPackageNames.join('\n'));
+
+                    ctx.didSomething = true;
+                }
+
                 next(err);
             });
         },
@@ -343,22 +447,28 @@ function do_volapi(subcmd, opts, args, cb) {
             });
         },
         function enableNfSharedVolumes(ctx, next) {
-            self.progress('Setting experimental_nfs_shared_volumes=true on '
-                + 'Docker service');
-            ctx.didSomething = true;
-
-            self.sdcadm.sapi.updateService(ctx.dockerSvc.uuid, {
-                action: 'update',
-                metadata: {
-                    experimental_nfs_shared_volumes: true
+            function _nfsSharedVolumesEnabled(err, didEnable) {
+                if (didEnable) {
+                    self.progress('Set experimental_nfs_shared_volumes=true on '
+                        + 'Docker service');
+                    ctx.didSomething = true;
                 }
-            }, next);
+
+                next(err);
+            }
+
+            enableNfsSharedVolumesInDocker(ctx.dockerSvc.uuid, {
+                sapiClient: self.sdcadm.sapi
+            }, _nfsSharedVolumesEnabled);
         },
         function done(ctx, next) {
             if (ctx.didSomething) {
                 self.progress('Setup "volapi" (%ds)',
                     Math.floor((Date.now() - start) / 1000));
+            } else {
+                self.progress('"volapi" is already set up');
             }
+
             next();
         }
     ]}, cb);
@@ -369,14 +479,9 @@ do_volapi.options = [
         names: ['help', 'h'],
         type: 'bool',
         help: 'Show this help.'
-    },
-    {
-        names: ['img-source', 's'],
-        type: 'string',
-        help: 'The URL of the images repository from which to download '
-            + 'volapi\'s image'
     }
 ];
+
 do_volapi.help = (
     'Create the "volapi" service and a first instance.\n' +
     '\n' +

--- a/lib/cli/do_volapi.js
+++ b/lib/cli/do_volapi.js
@@ -1,0 +1,393 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2016, Joyent, Inc.
+ */
+
+/*
+ * The 'sdcadm experimental volapi' CLI subcommand.
+ */
+
+var assert = require('assert-plus');
+var util = require('util'),
+    format = util.format;
+var vasync = require('vasync');
+
+var common = require('../common');
+var errors = require('../errors');
+var DownloadImages = require('../procedures/download-images').DownloadImages;
+var shared = require('../procedures/shared');
+
+var NB_MBS_IN_GB = 1024;
+var NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX = 'nfs_shared_volume_';
+// Sizes are in GBs
+var NFS_SHARED_VOLUMES_PKG_SIZES = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100,
+    200, 300, 400, 500, 600, 700, 800, 900, 1000];
+
+/**
+ * This is the template used for creating package objects for NFS shared
+ * volumes. The size and owners' uuid are setup at runtime.
+ */
+var NFS_SHARED_VOLUMES_PACKAGE_TEMPLATE = {
+    active: true,
+    cpu_cap: 100,
+    max_lwps: 1000,
+    max_physical_memory: 1024,
+    max_swap: 1024,
+    vcpus: 1,
+    version: '1.0.0',
+    zfs_io_priority: 20,
+    default: false
+};
+
+/**
+ * Adds a package using PAPI client "papiClient" for shared NFS volumes of size
+ * "size" GBs. Calls "callback" when done with an error object and the newly
+ * created package as parameters.
+ */
+function addSharedVolumePackage(cli, packageSettings, callback) {
+    assert.object(cli, 'cli');
+    assert.object(packageSettings, 'packageSettings');
+    assert.number(packageSettings.size, 'size');
+    assert.arrayOfString(packageSettings.owner_uuids,
+        'packageSettings.owner_uuids');
+    assert.func(callback, 'callback');
+
+    var papiClient = cli.sdcadm.papi;
+
+    var packageName = NFS_SHARED_VOLUMES_PACKAGES_NAME_PREFIX
+        + packageSettings.size;
+    cli.progress(util.format('Creating "%s" package', packageName));
+
+    var newPackage = {
+        name: packageName,
+        quota: packageSettings.size * NB_MBS_IN_GB,
+        owner_uuids: packageSettings.owner_uuids
+    };
+
+    common.objCopy(NFS_SHARED_VOLUMES_PACKAGE_TEMPLATE, newPackage);
+
+    papiClient.add(newPackage, callback);
+}
+
+function do_volapi(subcmd, opts, args, cb) {
+    var self = this;
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length > 0) {
+        return cb(new errors.UsageError('too many args: ' + args));
+    }
+
+    var start = Date.now();
+    var svcData = {
+        name: 'volapi',
+        params: {
+            package_name: 'sdc_1024',
+            billing_id: 'TO_FILL_IN', // filled in from 'package_name'
+            image_uuid: 'TO_FILL_IN',
+            archive_on_delete: true,
+            delegate_dataset: true,
+            maintain_resolvers: true,
+            networks: [
+                {name: 'admin'}
+            ],
+            firewall_enabled: false,
+            tags: {
+                smartdc_role: 'volapi',
+                smartdc_type: 'core'
+            }
+        },
+        metadata: {
+            SERVICE_NAME: 'volapi',
+            SERVICE_DOMAIN: 'TO_FILL_IN',
+            'user-script': 'TO_FILL_IN'
+        }
+    };
+
+
+    var context = {
+        imgsToDownload: [],
+        didSomething: false
+    };
+
+    vasync.pipeline({arg: context, funcs: [
+        function getPkg(ctx, next) {
+            var filter = {name: svcData.params.package_name,
+                active: true};
+            self.sdcadm.papi.list(filter, {}, function (err, pkgs) {
+                if (err) {
+                    return next(err);
+                } else if (pkgs.length !== 1) {
+                    return next(new errors.InternalError({
+                        message: format('%d "%s" packages found', pkgs.length,
+                            svcData.params.package_name)
+                    }));
+                }
+                ctx.volapiPkg = pkgs[0];
+                next();
+            });
+        },
+
+        function ensureSapiMode(_, next) {
+            // Bail if SAPI not in 'full' mode.
+            self.sdcadm.sapi.getMode(function (err, mode) {
+                if (err) {
+                    next(new errors.SDCClientError(err, 'sapi'));
+                } else if (mode !== 'full') {
+                    next(new errors.UpdateError(format(
+                        'SAPI is not in "full" mode: mode=%s', mode)));
+                } else {
+                    next();
+                }
+            });
+        },
+
+        function getSvc(ctx, next) {
+            self.sdcadm.sapi.listServices({
+                name: 'volapi',
+                application_uuid: self.sdcadm.sdc.uuid
+            }, function (svcErr, svcs) {
+                if (svcErr) {
+                    return next(svcErr);
+                } else if (svcs.length) {
+                    ctx.volapiSvc = svcs[0];
+                }
+                next();
+            });
+        },
+
+        function getVolApiInst(ctx, next) {
+            if (!ctx.volapiSvc) {
+                return next();
+            }
+            var filter = {
+                service_uuid: ctx.volapiSvc.uuid
+            };
+            self.sdcadm.sapi.listInstances(filter, function (err, insts) {
+                if (err) {
+                    return next(new errors.SDCClientError(err, 'sapi'));
+                } else if (insts && insts.length) {
+                    // Note this doesn't handle multiple insts.
+                    ctx.volapiInst = insts[0];
+                    self.sdcadm.vmapi.getVm({
+                        uuid: ctx.volapiInst.uuid
+                    }, function (vmErr, volapiVm) {
+                        if (vmErr) {
+                            return next(vmErr);
+                        }
+                        ctx.volapiVm = volapiVm;
+                        next();
+                    });
+                } else {
+                    next();
+                }
+            });
+        },
+
+        function getLatestVolApiImage(ctx, next) {
+            var filter = {name: 'volapi'};
+            self.sdcadm.updates.listImages(filter, function (err, images) {
+                if (err) {
+                    next(err);
+                } else if (images && images.length) {
+                    // TODO presuming sorted
+                    ctx.volapiImg = images[images.length - 1];
+                    next();
+                } else {
+                    next(new errors.UpdateError('no "volapi" image found'));
+                }
+            });
+        },
+
+        function haveVolApiImageAlready(ctx, next) {
+            self.sdcadm.imgapi.getImage(ctx.volapiImg.uuid,
+                    function (err, img_) {
+                if (err && err.body && err.body.code === 'ResourceNotFound') {
+                    ctx.imgsToDownload.push(ctx.volapiImg);
+                } else if (err) {
+                    return next(err);
+                }
+                next();
+            });
+        },
+
+        function importImages(ctx, next) {
+            if (ctx.imgsToDownload.length === 0) {
+                return next();
+            }
+            var proc = new DownloadImages({
+                images: ctx.imgsToDownload,
+                source: opts['img-source']
+            });
+            proc.execute({
+                sdcadm: self.sdcadm,
+                log: self.log,
+                progress: self.progress
+            }, next);
+        },
+
+        /* @field ctx.userString */
+        shared.getUserScript,
+
+        function createVolApiSvc(ctx, next) {
+            if (ctx.volapiSvc) {
+                return next();
+            }
+
+            var domain = self.sdcadm.sdc.metadata.datacenter_name + '.' +
+                    self.sdcadm.sdc.metadata.dns_domain;
+            var svcDomain = svcData.name + '.' + domain;
+
+            self.progress('Creating "volapi" service');
+            ctx.didSomething = true;
+
+            svcData.params.image_uuid = ctx.volapiImg.uuid;
+            svcData.metadata['user-script'] = ctx.userScript;
+            svcData.metadata['SERVICE_DOMAIN'] = svcDomain;
+            svcData.params.billing_id = ctx.volapiPkg.uuid;
+            delete svcData.params.package_name;
+
+            self.sdcadm.sapi.createService('volapi', self.sdcadm.sdc.uuid,
+                    svcData, function (err, svc) {
+                if (err) {
+                    return next(new errors.SDCClientError(err, 'sapi'));
+                }
+                ctx.volapiSvc = svc;
+                self.log.info({svc: svc}, 'created volapi svc');
+                next();
+            });
+        },
+
+        /* @field ctx.headnode */
+        function getHeadnode(ctx, next) {
+            self.sdcadm.cnapi.listServers({
+                headnode: true
+            }, function (err, servers) {
+                if (err) {
+                    return next(new errors.SDCClientError(err, 'cnapi'));
+                }
+                ctx.headnode = servers[0];
+                return next();
+            });
+        },
+        function createVolApiInst(ctx, next) {
+            if (ctx.volapiInst) {
+                return next();
+            }
+
+            self.progress('Creating "volapi" instance');
+            ctx.didSomething = true;
+
+            var instOpts = {
+                params: {
+                    alias: 'volapi0',
+                    server_uuid: ctx.headnode.uuid
+                }
+            };
+            self.sdcadm.sapi.createInstance(ctx.volapiSvc.uuid, instOpts,
+                    function (err, inst) {
+                if (err) {
+                    return next(new errors.SDCClientError(err, 'sapi'));
+                }
+                self.progress('Created VM %s (%s)', inst.uuid,
+                    inst.params.alias);
+                ctx.newVolApiInst = inst;
+                next();
+            });
+        },
+        function addSharedVolumesPackages(ctx, next) {
+            function createPackageSettings(packageSize) {
+                assert.number(packageSize, 'packageSize');
+                assert.ok(packageSize > 0);
+
+                return {
+                    size: packageSize,
+                    owner_uuids: [self.sdcadm.config.ufds_admin_uuid]
+                };
+            }
+
+            var packagesSettings =
+                NFS_SHARED_VOLUMES_PKG_SIZES.map(createPackageSettings);
+
+            self.progress('Adding NFS shared volume packages');
+            ctx.didSomething = true;
+
+            vasync.forEachParallel({
+                func: addSharedVolumePackage.bind(null, self),
+                inputs: packagesSettings
+            }, function sharedVolumesPackagesAdded(err) {
+                if (err) {
+                    console.error(util.inspect(err, {depth:null}));
+                }
+                self.progress('NFS shared volume packages added');
+                next(err);
+            });
+        },
+        function getDockerServiceUuid(ctx, next) {
+            self.sdcadm.sapi.listServices({
+                name: 'docker',
+                application_uuid: self.sdcadm.sdc.uuid
+            }, function (svcErr, svcs) {
+                if (svcErr) {
+                    return next(svcErr);
+                } else if (svcs.length) {
+                    ctx.dockerSvc = svcs[0];
+                }
+
+                next();
+            });
+        },
+        function enableNfSharedVolumes(ctx, next) {
+            self.progress('Setting experimental_nfs_shared_volumes=true on '
+                + 'Docker service');
+            ctx.didSomething = true;
+
+            self.sdcadm.sapi.updateService(ctx.dockerSvc.uuid, {
+                action: 'update',
+                metadata: {
+                    experimental_nfs_shared_volumes: true
+                }
+            }, next);
+        },
+        function done(ctx, next) {
+            if (ctx.didSomething) {
+                self.progress('Setup "volapi" (%ds)',
+                    Math.floor((Date.now() - start) / 1000));
+            }
+            next();
+        }
+    ]}, cb);
+}
+
+do_volapi.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['img-source', 's'],
+        type: 'string',
+        help: 'The URL of the images repository from which to download '
+            + 'volapi\'s image'
+    }
+];
+do_volapi.help = (
+    'Create the "volapi" service and a first instance.\n' +
+    '\n' +
+    'Usage:\n' +
+    '     {{name}} volapi\n' +
+    '\n' +
+    '{{options}}'
+);
+
+// --- exports
+
+module.exports = {
+    do_volapi: do_volapi
+};

--- a/lib/cli/experimental.js
+++ b/lib/cli/experimental.js
@@ -101,6 +101,8 @@ require('./do_install_docker_cert').do_install_docker_cert;
 ExperimentalCLI.prototype.do_cns =
 require('./do_cns').do_cns;
 
+ExperimentalCLI.prototype.do_volapi =
+require('./do_volapi').do_volapi;
 
 
 //---- exports

--- a/lib/procedures/index.js
+++ b/lib/procedures/index.js
@@ -174,7 +174,7 @@ function coordinatePlan(opts, cb) {
                 'manta',
                 'napi', 'portolan',
                 'papi',
-                'rabbitmq', 'redis', 'sdc', 'vmapi', 'workflow'];
+                'rabbitmq', 'redis', 'sdc', 'volapi', 'vmapi', 'workflow'];
             var handle = [];
             var remaining = [];
             var currHostname = os.hostname();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a SmartDataCenter (SDC) standup",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a SmartDataCenter (SDC) standup",
-  "version": "1.11.1",
+  "version": "1.11.3",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This allows users of Triton to run:

```
$ sdcadm experimental volapi
```

to create a Volumes API service and instance that can be used to [create/mount NFS shared volumes with docker on Triton](https://github.com/joyent/sdc-docker/pull/78).
