### PR TITLE
TOOLS-1823 split sdcadm experimental volapi into sdcadm postsetup and sdcadm experimental commands

### DIFF
--- a/lib/cli/do_nfs_volumes.js
+++ b/lib/cli/do_nfs_volumes.js
@@ -26,6 +26,7 @@ var vasync = require('vasync');
 var common = require('../common');
 var errors = require('../errors');
 var shared = require('../procedures/shared');
+var uuid = require('../uuid');
 
 function getCoreServiceImageVersion(coreServiceName, options, callback) {
     assert.string(coreServiceName, 'coreServiceName');
@@ -88,6 +89,12 @@ function getCoreServiceImageVersion(coreServiceName, options, callback) {
         },
         function getInstImage(ctx, next) {
             assert.object(ctx.instVm, 'ctx.instVm');
+
+            if (!uuid.validUuid(ctx.instVm.image_uuid)) {
+                next(new Error('VM for service ' + coreServiceName + ' has ' +
+                    'an invalid image_uuid: ' + ctx.instVm.image_uuid));
+                return;
+            }
 
             imgapiClient.getImage(ctx.instVm.image_uuid,
                 function onGetImg(getImgErr, img) {
@@ -254,26 +261,6 @@ function do_nfs_volumes(subcmd, opts, args, cb) {
             self.progress('Checking if experimental_nfs_shared_volumes=' +
                 desiredNfsSharedVolumesFlagValue + ' in SDC app...');
 
-            function _nfsSharedVolumesUpdated(err, result) {
-                var errMsg;
-
-                if (!err) {
-                    if (result === desiredNfsSharedVolumesFlagValue) {
-                        self.progress('experimental_nfs_shared_volumes set ' +
-                            'to ' + desiredNfsSharedVolumesFlagValue + ' on ' +
-                            'SDC app');
-                    } else {
-                        errMsg = 'Could not set ' +
-                            'experimental_nfs_shared_volumes to ' +
-                            desiredNfsSharedVolumesFlagValue + ' on SDC app';
-                        self.progress(errMsg);
-                        err = new Error(errMsg);
-                    }
-                }
-
-                next(err);
-            }
-
             if (self.sdcadm.sdc.metadata.experimental_nfs_shared_volumes !==
                 desiredNfsSharedVolumesFlagValue) {
                 ctx.didSomething = true;
@@ -284,7 +271,26 @@ function do_nfs_volumes(subcmd, opts, args, cb) {
                 updateNfsSharedVolumesInSdc(desiredNfsSharedVolumesFlagValue, {
                     sdcApp: self.sdcadm.sdc,
                     sapiClient: self.sdcadm.sapi
-                }, _nfsSharedVolumesUpdated);
+                }, function _nfsSharedVolumesUpdated(err, result) {
+                    var errMsg;
+
+                    if (!err) {
+                        if (result === desiredNfsSharedVolumesFlagValue) {
+                            self.progress('experimental_nfs_shared_volumes ' +
+                                'set to ' + desiredNfsSharedVolumesFlagValue +
+                                ' on SDC app');
+                        } else {
+                            errMsg = 'Could not set ' +
+                                'experimental_nfs_shared_volumes to ' +
+                                desiredNfsSharedVolumesFlagValue + ' on SDC ' +
+                                'app';
+                            self.progress(errMsg);
+                            err = new Error(errMsg);
+                        }
+                    }
+
+                    next(err);
+                });
             } else {
                 self.progress('experimental_nfs_shared_volumes already set ' +
                     'to ' + desiredNfsSharedVolumesFlagValue + ', nothing ' +

--- a/lib/cli/do_nfs_volumes.js
+++ b/lib/cli/do_nfs_volumes.js
@@ -1,0 +1,341 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+/*
+ * The 'sdcadm experimental nfs-volumes' CLI subcommand.
+ *
+ * Currently, NFS shared volumes are still at the prototype stage, and
+ * they must be enabled/disabled by setting a SAPI configuration flag.
+ */
+
+var assert = require('assert-plus');
+var https = require('https');
+var once = require('once');
+var util = require('util'),
+    format = util.format;
+var vasync = require('vasync');
+
+
+var common = require('../common');
+var errors = require('../errors');
+var shared = require('../procedures/shared');
+
+function getCoreServiceImageVersion(coreServiceName, options, callback) {
+    assert.string(coreServiceName, 'coreServiceName');
+    assert.object(options, 'options');
+    assert.object(options.imgapiClient, 'options.imgapiClient');
+    assert.object(options.sapiClient, 'options.sapiClient');
+    assert.object(options.sdcApplication, 'options.sdcApplication');
+    assert.object(options.vmapiClient, 'options.vmapiClient');
+    assert.func(callback, 'callback');
+
+    var context = {};
+    var imgapiClient = options.imgapiClient;
+    var sapiClient = options.sapiClient;
+    var sdcApp = options.sdcApplication;
+    var vmapiClient = options.vmapiClient;
+
+    vasync.pipeline({arg: context, funcs: [
+        function getSvc(ctx, next) {
+            sapiClient.listServices({
+                name: coreServiceName,
+                application_uuid: sdcApp.uuid
+            }, function (svcErr, svcs) {
+                if (svcErr) {
+                    next(svcErr);
+                    return;
+                } else if (svcs && svcs.length > 0) {
+                    ctx.svc = svcs[0];
+                }
+                next();
+            });
+        },
+
+        function getInst(ctx, next) {
+            assert.object(ctx.svc, 'ctx.svc');
+
+            var filter = {
+                service_uuid: ctx.svc.uuid
+            };
+
+            sapiClient.listInstances(filter, function (err, insts) {
+                if (err) {
+                    return next(new errors.SDCClientError(err, 'sapi'));
+                } else if (insts && insts.length) {
+                    // Note this doesn't handle multiple insts.
+                    ctx.inst = insts[0];
+                    vmapiClient.getVm({
+                        uuid: ctx.inst.uuid
+                    }, function (vmErr, instVm) {
+                        if (vmErr) {
+                            return next(vmErr);
+                        }
+
+                        ctx.instVm = instVm;
+                        next();
+                    });
+                } else {
+                    next();
+                }
+            });
+        },
+        function getInstImage(ctx, next) {
+            assert.object(ctx.instVm, 'ctx.instVm');
+
+            imgapiClient.getImage(ctx.instVm.image_uuid,
+                function onGetImg(getImgErr, img) {
+                    ctx.img = img;
+                    next(getImgErr);
+                });
+        }
+    ]}, function onDone(err) {
+        callback(err, {
+            serviceName: coreServiceName,
+            version: context.img.version
+        });
+    });
+
+}
+
+function getImagesVersions(coreServicesNames, options, callback) {
+    assert.arrayOfString(coreServicesNames, 'coreServicesNames');
+    assert.object(options, 'options');
+    assert.func(callback, 'callback');
+
+    vasync.forEachParallel({
+        func: function doGetCoreServiceImageVersion(coreServiceName, done) {
+            getCoreServiceImageVersion(coreServiceName, options, done);
+        },
+        inputs: coreServicesNames
+    }, function onImagesVersions(err, results) {
+        callback(err, results.successes);
+    });
+}
+
+function updateNfsSharedVolumesInSdc(desiredValue, options, callback) {
+    assert.bool(desiredValue, 'desiredValue');
+    assert.object(options, 'options');
+    assert.object(options.sdcApp, 'options.sdcApp');
+    assert.object(options.sapiClient, 'options.sapiClient');
+    assert.func(callback, 'callback');
+
+    var sapiClient = options.sapiClient;
+    var sdcApp = options.sdcApp;
+
+    sapiClient.updateApplication(sdcApp.uuid, {
+        metadata: {
+            experimental_nfs_shared_volumes: desiredValue
+        }
+    }, function onSdcAppUpdated(sapiErr, updatedSdcAdpp) {
+        callback(sapiErr,
+            updatedSdcAdpp.metadata.experimental_nfs_shared_volumes);
+    });
+}
+
+function do_nfs_volumes(subcmd, opts, args, cb) {
+    var self = this;
+
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length > 0) {
+        return cb(new errors.UsageError('too many args: ' + args));
+    }
+
+    var start = Date.now();
+
+    var context = {
+        didSomething: false
+    };
+
+    vasync.pipeline({arg: context, funcs: [
+        function getDependenciesImageVersions(ctx, next) {
+            if (opts.force === true) {
+                next();
+                return;
+            }
+
+            if (opts.disable === true) {
+                next();
+                return;
+            }
+
+            self.progress('Getting dependencies versions...');
+
+            /*
+             * We don't need to check for versions of CloudAPI and sdc-docker
+             * services since not updating them to a version that does not
+             * support NFS volumes has no impact on other services.
+             */
+            getImagesVersions(['volapi', 'vmapi', 'workflow'], {
+                imgapiClient: self.sdcadm.imgapi,
+                sapiClient: self.sdcadm.sapi,
+                sdcApplication: self.sdcadm.sdc,
+                vmapiClient: self.sdcadm.vmapi
+            }, function onGotImagesVersions(getImgVersErr, imagesVersions) {
+                if (!getImgVersErr) {
+                    self.progress('Got dependencies versions!');
+                }
+
+                ctx.imagesVersions = imagesVersions;
+                next(getImgVersErr);
+            });
+        },
+
+        function checkAllDependencies(ctx, next) {
+            var err;
+            var outdatedVersions;
+
+            if (opts.force === true) {
+                next();
+                return;
+            }
+
+            if (opts.disable === true) {
+                next();
+                return;
+            }
+
+            assert.arrayOfObject(ctx.imagesVersions, 'ctx.imagesVersions');
+
+            self.progress('Checking dependencies are up to date');
+
+            outdatedVersions =
+                ctx.imagesVersions.filter(function filterOutdated(versionInfo) {
+                    var serviceName = versionInfo.serviceName;
+                    var version = versionInfo.version;
+
+                    assert.string(serviceName, 'serviceName');
+                    assert.string(version, 'version');
+
+                    self.progress('Checking service ' + serviceName + ' at ' +
+                        'version ' + version + ' is up to date');
+
+                    /*
+                     * When this is submitted to be merged in master, this
+                     * ^tritonnfs pattern needs to be updated to a different
+                     * test that checks that "version" represents a version that
+                     * is at least as recent as the first build of the
+                     * corresponding service with NFS volumes support.
+                     */
+                    if (/^tritonnfs/.test(version)) {
+                        return false;
+                    }
+
+                    return true;
+                });
+
+            if (outdatedVersions && outdatedVersions.length > 0) {
+                err = new Error('Found outdated core services: ' +
+                    outdatedVersions.map(renderVersionInfo).join(', '));
+            }
+
+            function renderVersionInfo(versionInfo) {
+                return versionInfo.serviceName + ' at version ' +
+                    versionInfo.version;
+            }
+
+            next(err);
+        },
+
+        function updateNfSharedVolumesFlag(ctx, next) {
+            var desiredNfsSharedVolumesFlagValue = true;
+            if (opts.disable === true) {
+                desiredNfsSharedVolumesFlagValue = false;
+            }
+
+            self.progress('Checking if experimental_nfs_shared_volumes=' +
+                desiredNfsSharedVolumesFlagValue + ' in SDC app...');
+
+            function _nfsSharedVolumesUpdated(err, result) {
+                var errMsg;
+
+                if (!err) {
+                    if (result === desiredNfsSharedVolumesFlagValue) {
+                        self.progress('experimental_nfs_shared_volumes set ' +
+                            'to ' + desiredNfsSharedVolumesFlagValue + ' on ' +
+                            'SDC app');
+                    } else {
+                        errMsg = 'Could not set ' +
+                            'experimental_nfs_shared_volumes to ' +
+                            desiredNfsSharedVolumesFlagValue + ' on SDC app';
+                        self.progress(errMsg);
+                        err = new Error(errMsg);
+                    }
+                }
+
+                next(err);
+            }
+
+            if (self.sdcadm.sdc.metadata.experimental_nfs_shared_volumes !==
+                desiredNfsSharedVolumesFlagValue) {
+                ctx.didSomething = true;
+
+                self.progress('Setting experimental_nfs_shared_volumes to ' +
+                    desiredNfsSharedVolumesFlagValue + ' in SDC app...');
+
+                updateNfsSharedVolumesInSdc(desiredNfsSharedVolumesFlagValue, {
+                    sdcApp: self.sdcadm.sdc,
+                    sapiClient: self.sdcadm.sapi
+                }, _nfsSharedVolumesUpdated);
+            } else {
+                self.progress('experimental_nfs_shared_volumes already set ' +
+                    'to ' + desiredNfsSharedVolumesFlagValue + ', nothing ' +
+                    'to do');
+
+                next();
+            }
+        },
+
+        function done(ctx, next) {
+            if (ctx.didSomething) {
+                self.progress('Setup "volapi" (%ds)',
+                    Math.floor((Date.now() - start) / 1000));
+            } else {
+                self.progress('"volapi" is already set up');
+            }
+
+            next();
+        }
+    ]}, cb);
+}
+
+do_nfs_volumes.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['force', 'f'],
+        type: 'bool',
+        help: 'Force enable/disable NFS volumes, regardless of prerequisites.'
+    },
+    {
+        names: ['disable', 'd'],
+        type: 'bool',
+        help: 'Disable NFS volumes instead of enabling it'
+    }
+];
+
+do_nfs_volumes.help = (
+    'Enables/disables support for NFS volumes.\n' +
+    '\n' +
+    'Usage:\n' +
+    '     {{name}} nfs_volumes\n' +
+    '\n' +
+    '{{options}}'
+);
+
+// --- exports
+
+module.exports = {
+    do_nfs_volumes: do_nfs_volumes
+};

--- a/lib/cli/experimental.js
+++ b/lib/cli/experimental.js
@@ -80,8 +80,8 @@ require('./do_install_docker_cert').do_install_docker_cert;
 // Deprecated: TOOLS-1667
 ExperimentalCLI.prototype.do_cns = require('../post-setup/cns').do_cns;
 
-ExperimentalCLI.prototype.do_volapi =
-require('./do_volapi').do_volapi;
+ExperimentalCLI.prototype.do_nfs_volumes =
+require('./do_nfs_volumes').do_nfs_volumes;
 
 
 //---- exports

--- a/lib/post-setup/index.js
+++ b/lib/post-setup/index.js
@@ -74,7 +74,7 @@ PostSetupCLI.prototype.do_dev_sample_data =
 PostSetupCLI.prototype.do_docker = require('./docker').do_docker;
 PostSetupCLI.prototype.do_cmon = require('./cmon').do_cmon;
 PostSetupCLI.prototype.do_cns = require('./cns').do_cns;
-
+PostSetupCLI.prototype.do_volapi = require('./volapi').do_volapi;
 //---- exports
 
 module.exports = {

--- a/lib/post-setup/volapi.js
+++ b/lib/post-setup/volapi.js
@@ -9,7 +9,7 @@
  */
 
 /*
- * The 'sdcadm experimental volapi' CLI subcommand.
+ * The 'sdcadm post-setup volapi' CLI subcommand.
  */
 
 var assert = require('assert-plus');
@@ -111,26 +111,6 @@ function addSharedVolumePackage(cli, packageSettings, callback) {
         arg: context
     }, function _addSharedVolumePackageDone(err) {
         callback(err, context.pkgAdded);
-    });
-}
-
-function enableNfsSharedVolumesInSdc(sdcApp, options, callback) {
-    assert.object(sdcApp, 'sdcApp');
-    assert.object(options, 'options');
-    assert.object(options.sapiClient, 'options.sapiClient');
-    assert.func(callback, 'callback');
-
-    var sapiClient = options.sapiClient;
-
-    sapiClient.updateApplication(sdcApp.uuid, {
-        metadata: {
-            experimental_nfs_shared_volumes: true
-        }
-    }, function onSdcAppUpdated(sapiErr, updatedSdcAdpp) {
-        callback(sapiErr, {
-            alreadySet: false,
-            nowSet: updatedSdcAdpp.metadata.experimental_nfs_shared_volumes
-        });
     });
 }
 
@@ -500,43 +480,6 @@ function do_volapi(subcmd, opts, args, cb) {
 
                 next(err);
             });
-        },
-
-        // Currently, NFS shared volumes are still at the prototype stage, and
-        // they must be enabled by setting a SAPI configuration flag.
-        function enableNfSharedVolumes(ctx, next) {
-            self.progress('Checking if experimental_nfs_shared_volumes=true ' +
-                'in SDC app...');
-
-            function _nfsSharedVolumesEnabled(err, result) {
-                var errMsg;
-
-                if (!err) {
-                    if (result.nowSet) {
-                        self.progress('experimental_nfs_shared_volumes set ' +
-                            'to true on SDC app');
-                    } else {
-                        errMsg = 'Could not set ' +
-                            'experimental_nfs_shared_volumes to true on SDC ' +
-                            'app';
-                        self.progress(errMsg);
-                        err = new Error(errMsg);
-                    }
-                }
-
-                next(err);
-            }
-
-            if (self.sdcadm.sdc.metadata.experimental_nfs_shared_volumes !==
-                true) {
-                ctx.didSomething = true;
-
-                enableNfsSharedVolumesInSdc(self.sdcadm.sdc, {
-                    sapiClient: self.sdcadm.sapi
-                }, _nfsSharedVolumesEnabled);
-            } else {
-                next();
-            }
         },
 
         function done(ctx, next) {

--- a/lib/uuid.js
+++ b/lib/uuid.js
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2017, Joyent, Inc.
+ */
+
+var UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+function validUuid(uuid) {
+    return typeof (uuid) === 'string' && UUID_RE.test(uuid);
+}
+
+module.exports = {
+    validUuid: validUuid
+};


### PR DESCRIPTION
TOOLS-1822 sdcadm experimental volapi should check that images of required core services support NFS volumes