### PR TITLE
TRITON-1979 add 'sdcadm post-setup manta' replacement for setup_manta_zone.sh

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,17 @@
 
 # sdcadm Changelog
 
+## 1.33.0
+
+- TRITON-1979, TRITON-1981: Add `sdcadm post-setup manta` to be used to create
+  the manta deployment zone. This will become the first step to deploying a
+  Manta on Triton (https://joyent.github.io/manta/#deploying-manta) and will
+  replace the old `/usbkey/scripts/setup_manta_zone.sh`.
+
+  By default this will create a manta deployment zone suitable for a "mantav2".
+  See https://github.com/joyent/manta/blob/master/docs/mantav2.md for details
+  on mantav1 vs. mantav2.
+
 ## 1.32.0
 
 - TRITON-1980 Add support for multiple valid image names for a service

--- a/etc/defaults.json
+++ b/etc/defaults.json
@@ -21,7 +21,6 @@
         "binder": ["mantav2-nameservice", "manta-nameservice"],
         "mahi": ["mantav2-authcache", "manta-authcache"],
         "sdc": ["sdc"],
-        "manta": ["manta-deployment"],
         "sapi": ["sapi"],
         "cloudapi": ["cloudapi"],
         "napi": ["napi"],

--- a/lib/manta.js
+++ b/lib/manta.js
@@ -1,0 +1,281 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+/*
+ * Data and utilty functions for handling the manta deployment zone
+ * (the "manta" service on the "sdc" SAPI app).
+ */
+
+const assert = require('assert-plus');
+const vasync = require('vasync');
+const VError = require('verror');
+
+const common = require('./common');
+const errors = require('./errors');
+
+
+// Also include older "manta-deployment" images to support usage
+// through the transition period.
+const MANTAV1_IMG_NAMES = ['mantav1-deployment', 'manta-deployment'];
+const MANTAV2_IMG_NAMES = ['mantav2-deployment'];
+
+
+// Dev Note: We cannot use `sdcadm.getApp` because we must use
+// `include_master=true` for multi-DC manta.
+function getMantaApp(sapi, cb) {
+    sapi.listApplications({
+        name: 'manta',
+        include_master: 'true'
+    }, function (err, apps) {
+        if (err) {
+            cb(new errors.SDCClientError(err, 'sapi'));
+            return;
+        }
+
+        assert.ok(apps.length <= 1, 'zero or one "manta" SAPI apps');
+        if (apps.length === 0) {
+            cb(null, null);
+        } else {
+            cb(null, apps[0]);
+        }
+    });
+}
+
+// Get the current "mantav", the major version of the current Manta.
+//
+// This is one of three possible values:
+// - `null` - There is no "manta" SAPI app in this region (set of linked DCs,
+//   https://github.com/joyent/sdc-sapi/blob/master/docs/index.md#multi-dc-mode)
+// - `1` - Either the `$mantaApp.metadata.MANTAV` is set to the number 1, or
+//   it is not set.
+// - `2` - `$mantaApp.metadata.MANTAV` is set to the number 2.
+//
+// Any other value results in this calling back with an error.
+function getMantav(sdcadm, cb) {
+    assert.object(sdcadm, 'sdcadm');
+    assert.func(cb, 'cb');
+
+    getMantaApp(sdcadm.sapi, function (err, app) {
+        if (err) {
+            cb(err);
+        } else if (!app) {
+            cb(null, null);
+        } else {
+            let mantav = app.metadata.mantav;
+            if (mantav === undefined || mantav === 1) {
+                cb(null, 1);
+            } else if (mantav === 2) {
+                cb(null, 2);
+            } else {
+                cb(new VError(
+                    'invalid "metadata.MANTAV" on SAPI application %s ' +
+                        '(manta), must be 1, 2, or undefined: %s',
+                    app.uuid,
+                    JSON.stringify(mantav)));
+            }
+        }
+    });
+}
+
+
+// Determine the mantav based on the image used for a current manta deployment
+// zone (an instance of the "manta" service on the "sdc" SAPI app), if there
+// is one.
+//
+// Typically this is only called if `getMantav` could not determine a mantav,
+// i.e. if there is no "manta" SAPI *app*.
+//
+// As with `getMantav()` there are the same three possible values:
+// null, 1, or 2.
+function getMantaDeploymentV(sdcadm, cb) {
+    assert.object(sdcadm, 'sdcadm');
+    assert.func(cb, 'cb');
+
+    const context = {};
+    const log = sdcadm.log;
+
+    vasync.pipeline({
+        arg: context,
+        funcs: [
+            sdcadm.ensureSdcApp.bind(sdcadm),
+
+            function getCurrServerUuid(ctx, next) {
+                sdcadm.getCurrServerUuid(function (err, currServerUuid) {
+                    ctx.currServerUuid = currServerUuid;
+                    next(err);
+                });
+            },
+
+            // Dev Note: I'm avoiding using "SdcAdm.listInsts" because it (a)
+            // does too much and then (b) throws away the image info we need.
+            function getMantaSvc(ctx, next) {
+                sdcadm.getSvc({
+                    app: 'sdc',
+                    svc: 'manta',
+                    allowNone: true
+                }, function (err, svc) {
+                    if (err) {
+                        next(err);
+                    } else if (!svc) {
+                        // No "manta" service, so there is no set version.
+                        ctx.mantaDeploymentV = null;
+                        next();
+                    } else {
+                        ctx.svc = svc;
+                        next();
+                    }
+                });
+            },
+
+            function getMantaInst(ctx, next) {
+                if (ctx.hasOwnProperty('mantaDeploymentV')) {
+                    next();
+                    return;
+                }
+
+                sdcadm.sapi.listInstances({
+                    service_uuid: ctx.svc.uuid,
+                }, function onInsts(err, insts) {
+                    if (err) {
+                        next(new errors.SDCClientError(err, 'sapi'));
+                        return;
+                    }
+
+                    assert.ok(insts.length <= 1,
+                        'there are multiple SAPI instances of service ' +
+                        ctx.svc.uuid + ' (manta): ' + JSON.stringify(insts));
+                    if (insts.length === 0) {
+                        // No "manta" inst, so there is no set version.
+                        ctx.mantaDeploymentV = null;
+                    } else {
+                        ctx.inst = insts[0];
+                    }
+                    next();
+                });
+            },
+
+            function getMantaVm(ctx, next) {
+                if (ctx.hasOwnProperty('mantaDeploymentV')) {
+                    next();
+                    return;
+                }
+
+                sdcadm.vmapi.getVm({uuid: ctx.inst.uuid}, function (err, vm) {
+                    ctx.vm = vm;
+                    next(err);
+                });
+            },
+
+            // In general the image for a deployed VM could be removed from
+            // IMGAPI. However, that image has to be on the zpool and we know
+            // the manta zone has to be on the headnode, on which we are
+            // running this sdcadm. So we can just call `imgadm get $uuid`.
+            function getMantaImg(ctx, next) {
+                if (ctx.hasOwnProperty('mantaDeploymentV')) {
+                    next();
+                    return;
+                }
+
+                assert.uuid(ctx.vm.image_uuid, 'vm ' + ctx.vm.uuid +
+                    ' (' + ctx.vm.alias + ') has image_uuid');
+                assert.equal(ctx.vm.server_uuid, ctx.currServerUuid,
+                    'manta inst is on this server (the headnode): ' +
+                    ctx.vm.server_uuid);
+
+                common.spawnRun({
+                    argv: ['/usr/sbin/imgadm', 'get', ctx.vm.image_uuid],
+                    log: log
+                }, function (err, stdout, stderr) {
+                    if (err) {
+                        next(new VError(err,
+                            'could not get image %s for manta vm %s',
+                            ctx.vm.image_uuid, ctx.vm.uuid));
+                        return;
+                    }
+
+                    const img = JSON.parse(stdout).manifest;
+                    assert.string(img.name,
+                        'manta image manifest has a name');
+                    if (MANTAV1_IMG_NAMES.indexOf(img.name) !== -1) {
+                        ctx.mantaDeploymentV = 1;
+                        next();
+                    } else if (MANTAV2_IMG_NAMES.indexOf(img.name) !== -1) {
+                        ctx.mantaDeploymentV = 2;
+                        next();
+                    } else {
+                        next(new VError('unexpected image name on manta ' +
+                            'deployment vm %s: "%s"', ctx.vm.uuid, img.name));
+                    }
+                });
+            },
+        ]
+    }, function finish(err) {
+        if (err) {
+            cb(err);
+        } else {
+            log.debug({mantaDeploymentV: context.mantaDeploymentV},
+                'getMantaDeploymentV');
+            cb(null, context.mantaDeploymentV)
+        }
+    });
+}
+
+
+// Determine the set of appropriate image names for the Manta deployment
+// service.
+//
+// What image names to use depends on Manta state:
+// - If there is already a "manta" SAPI application, that will tell use if this
+//   is a mantav1 or a mantav2, then we return the appropriate image names for
+//   that manta version.
+// - Otherwise, if there is a manta deployment image provisioned (e.g. after a
+//   run of `sdcadm post-setup manta`), then stick with the appropriate manta
+//   version.
+// - Otherwise, default to mantav2 image names.
+function getImgNames(sdcadm, cb) {
+    assert.object(sdcadm, 'sdcadm');
+    assert.func(cb, 'cb');
+
+    getMantav(sdcadm, function (mvErr, mantav) {
+        if (mvErr) {
+            cb(mvErr);
+        } else if (mantav === 1) {
+            cb(null, MANTAV1_IMG_NAMES);
+        } else if (mantav === 2) {
+            cb(null, MANTAV2_IMG_NAMES);
+        } else {
+            getMantaDeploymentV(sdcadm, function (mdvErr, mantaDeploymentV) {
+                if (mdvErr) {
+                    cb(mdvErr);
+                } else if (mantaDeploymentV === 1) {
+                    cb(null, MANTAV1_IMG_NAMES);
+                } else if (mantaDeploymentV === 2) {
+                    cb(null, MANTAV2_IMG_NAMES);
+                } else {
+                    // Default if no manta application and no manta deployment
+                    // zone.
+                    cb(null, MANTAV2_IMG_NAMES);
+                }
+            });
+        }
+
+    });
+}
+
+
+// --- exports
+
+module.exports = {
+    MANTAV1_IMG_NAMES: MANTAV1_IMG_NAMES,
+    MANTAV2_IMG_NAMES: MANTAV2_IMG_NAMES,
+
+    getMantav: getMantav,
+    getImgNames: getImgNames
+};

--- a/lib/manta.js
+++ b/lib/manta.js
@@ -10,7 +10,8 @@
 
 /*
  * Data and utilty functions for handling the manta deployment zone
- * (the "manta" service on the "sdc" SAPI app).
+ * (a.k.a. the "manta" service on the "sdc" SAPI app, a.k.a. the image from
+ * sdc-manta.git).
  */
 
 const assert = require('assert-plus');
@@ -21,8 +22,11 @@ const common = require('./common');
 const errors = require('./errors');
 
 
-// Also include older "manta-deployment" images to support usage
-// through the transition period.
+// A mantav1 uses the existing "manta-deployment" images, and the new
+// images from the "mantav1" branch, "mantav1-deployment".
+//
+// A mantav2 exclusively uses "mantav2-deployment" images created from the
+// "master" branch after the branching is done.
 const MANTAV1_IMG_NAMES = ['mantav1-deployment', 'manta-deployment'];
 const MANTAV2_IMG_NAMES = ['mantav2-deployment'];
 
@@ -85,12 +89,14 @@ function getMantav(sdcadm, cb) {
 }
 
 
-// Determine the mantav based on the image used for a current manta deployment
+// Determine the "mantav" based on the image used for a current manta deployment
 // zone (an instance of the "manta" service on the "sdc" SAPI app), if there
 // is one.
 //
-// Typically this is only called if `getMantav` could not determine a mantav,
-// i.e. if there is no "manta" SAPI *app*.
+// This should only be called if `getMantav` could not determine a mantav,
+// i.e. if there is no "manta" SAPI *app*, and typically this information is
+// only useful for `sdcadm post-setup manta` to stick to the same version of
+// manta deployment images for an existing zone.
 //
 // As with `getMantav()` there are the same three possible values:
 // null, 1, or 2.
@@ -232,7 +238,7 @@ function getMantaDeploymentV(sdcadm, cb) {
 // service.
 //
 // What image names to use depends on Manta state:
-// - If there is already a "manta" SAPI application, that will tell use if this
+// - If there is already a "manta" SAPI application, that will tell us if this
 //   is a mantav1 or a mantav2, then we return the appropriate image names for
 //   that manta version.
 // - Otherwise, if there is a manta deployment image provisioned (e.g. after a

--- a/lib/manta.js
+++ b/lib/manta.js
@@ -141,7 +141,7 @@ function getMantaDeploymentV(sdcadm, cb) {
                 }
 
                 sdcadm.sapi.listInstances({
-                    service_uuid: ctx.svc.uuid,
+                    service_uuid: ctx.svc.uuid
                 }, function onInsts(err, insts) {
                     if (err) {
                         next(new errors.SDCClientError(err, 'sapi'));
@@ -214,7 +214,7 @@ function getMantaDeploymentV(sdcadm, cb) {
                             'deployment vm %s: "%s"', ctx.vm.uuid, img.name));
                     }
                 });
-            },
+            }
         ]
     }, function finish(err) {
         if (err) {
@@ -222,7 +222,7 @@ function getMantaDeploymentV(sdcadm, cb) {
         } else {
             log.debug({mantaDeploymentV: context.mantaDeploymentV},
                 'getMantaDeploymentV');
-            cb(null, context.mantaDeploymentV)
+            cb(null, context.mantaDeploymentV);
         }
     });
 }

--- a/lib/manta.js
+++ b/lib/manta.js
@@ -50,7 +50,7 @@ function getMantaApp(sapi, cb) {
 
 // Get the current "mantav", the major version of the current Manta.
 //
-// This is one of three possible values:
+// This are three possible values:
 // - `null` - There is no "manta" SAPI app in this region (set of linked DCs,
 //   https://github.com/joyent/sdc-sapi/blob/master/docs/index.md#multi-dc-mode)
 // - `1` - Either the `$mantaApp.metadata.MANTAV` is set to the number 1, or

--- a/lib/post-setup/do_manta.js
+++ b/lib/post-setup/do_manta.js
@@ -34,10 +34,10 @@ const runProcs = require('../procedures').runProcs;
 
 // ---- internal support functions
 
-function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
+function ensureMantaDeploymentSvcAndInst(cli, opts, wantMantav2, cb) {
     assert.object(cli, 'cli');
     assert.object(opts, 'opts');
-    assert.bool(isMantav2, 'isMantav2');
+    assert.bool(wantMantav2, 'wantMantav2');
     assert.func(cb, 'cb');
 
     const addServiceOpts = {
@@ -46,7 +46,7 @@ function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
         // The manta0 zone instance must be on the headnode. We could look that
         // up (`sdc-cnapi /servers?headnode=true | json -H 0.uuid`) or rely on
         // the `AddServiceProcedure` behaviour of defaulting to the current
-        // server. We do the later (sdcadm is run on the headnode).
+        // server. We do the latter (sdcadm is run on the headnode).
         //    server: ...,
         networks: [
             {name: 'admin'},
@@ -55,10 +55,7 @@ function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
         firewallEnabled: true
     };
 
-    // With the mantav1/mantav2 split there are new image names: images from
-    // master are "mantav2-*", images from the "mantav1" maintenance branches
-    // are "mantav1-*".
-    if (isMantav2) {
+    if (wantMantav2) {
         addServiceOpts.imgNames = manta.MANTAV2_IMG_NAMES;
     } else {
         addServiceOpts.imgNames = manta.MANTAV1_IMG_NAMES;
@@ -72,14 +69,14 @@ function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
         addServiceOpts.channel = opts.channel;
     }
 
-    if (isMantav2) {
+    if (wantMantav2) {
         cli.ui.info([
             /* eslint-disable max-len */
             'This will setup for a new Manta v2 deployment.',
             '',
-            'This creates a new manta0 zone on the headnode which provides the',
-            'tooling for deploying and maintaining a Manta installation. After this',
-            'step is complete, follow the Manta Operator Guide to deploy Manta:',
+            'This creates a zone on the headnode which provides the tooling for',
+            'deploying and maintaining a Manta installation. After this step is',
+            'complete, follow the Manta Operator Guide to deploy Manta:',
             '    https://joyent.github.io/manta/#deploying-manta'
             /* eslint-enable */
         ].join('\n'));
@@ -92,9 +89,9 @@ function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
             'See the following for information on mantav1 vs mantav2:',
             '    https://github.com/joyent/manta/blob/master/docs/mantav2.md',
             '',
-            'This creates a new manta0 zone on the headnode which provides the',
-            'tooling for deploying and maintaining a Manta installation. After this',
-            'step is complete, follow the Manta Operator Guide to deploy Manta:',
+            'This creates a zone on the headnode which provides the tooling for',
+            'deploying and maintaining a Manta installation. After this step is',
+            'complete, follow the Manta Operator Guide to deploy Manta:',
             '    https://github.com/joyent/manta/blob/mantav1/docs/operator-guide.md'
             /* eslint-enable */
         ].join('\n'));
@@ -126,12 +123,12 @@ function do_manta(subcmd, opts, args, cb) {
         return;
     }
 
-    let isMantav2 = true;
+    let wantMantav2 = true;
     if (opts.mantav1 && opts.mantav2) {
         cb(new errors.UsageError('cannot use both --mantav1 and --mantav2'));
         return;
     } else if (opts.mantav1) {
-        isMantav2 = false;
+        wantMantav2 = false;
     }
 
     // Ensure the current "mantav" (manta major version), if any, matches the
@@ -144,14 +141,14 @@ function do_manta(subcmd, opts, args, cb) {
         if (err) {
             cb(err);
             return;
-        } else if (mantav === 2 && !isMantav2) {
+        } else if (mantav === 2 && !wantMantav2) {
             cb(new VError('there is currently a mantav2 SAPI application, ' +
                 'cannot downgrade to mantav1'));
-        } else if (mantav === 1 && isMantav2) {
+        } else if (mantav === 1 && wantMantav2) {
             cb(new VError('there is currently a mantav1 SAPI application, ' +
                 'migrating to mantav2 is not yet supported'));
         } else {
-            ensureMantaDeploymentSvcAndInst(self, opts, isMantav2, cb);
+            ensureMantaDeploymentSvcAndInst(self, opts, wantMantav2, cb);
         }
     });
 }

--- a/lib/post-setup/do_manta.js
+++ b/lib/post-setup/do_manta.js
@@ -28,71 +28,13 @@ const EnsureMantaDeploymentGzLinksProcedure =
     require('../procedures/ensure-manta-deployment-gz-links')
     .EnsureMantaDeploymentGzLinksProcedure;
 const errors = require('../errors');
+const manta = require('../manta');
 const runProcs = require('../procedures').runProcs;
 
 
 // ---- internal support functions
 
-// Dev Note: We cannot use `sdcadm.getApp` because we must use
-// `include_master=true` for multi-DC manta.
-function getMantaApp(sapi, cb) {
-    sapi.listApplications({
-        name: 'manta',
-        include_master: 'true'
-    }, function (err, apps) {
-        if (err) {
-            cb(new errors.SDCClientError(err, 'sapi'));
-            return;
-        }
-
-        assert.ok(apps.length <= 1, 'zero or one "manta" SAPI apps');
-        if (apps.length === 0) {
-            cb(null, null);
-        } else {
-            cb(null, apps[0]);
-        }
-    });
-}
-
-// Get the current "mantav", the major version of the current Manta.
-//
-// This is one of three possible values:
-// - `null` - There is no "manta" SAPI app in this region (set of linked DCs,
-//   https://github.com/joyent/sdc-sapi/blob/master/docs/index.md#multi-dc-mode)
-// - `1` - Either the `$mantaApp.metadata.MANTAV` is set to the number 1, or
-//   it is not set.
-// - `2` - `$mantaApp.metadata.MANTAV` is set to the number 2.
-//
-// Any other value results in this calling back with an error.
-function getMantav(args, cb) {
-    assert.object(args, 'args');
-    assert.object(args.sdcadm, 'args.sdcadm');
-    assert.func(cb, 'cb');
-
-    getMantaApp(args.sdcadm.sapi, function (err, app) {
-        if (err) {
-            cb(err);
-        } else if (!app) {
-            cb(null, null);
-        } else {
-            let mantav = app.metadata.mantav;
-            if (mantav === undefined || mantav === 1) {
-                cb(null, 1);
-            } else if (mantav === 2) {
-                cb(null, 2);
-            } else {
-                cb(new VError(
-                    'invalid "metadata.MANTAV" on SAPI application %s ' +
-                        '(manta), must be 1, 2, or undefined: %s',
-                    app.uuid,
-                    JSON.stringify(mantav)));
-            }
-        }
-    });
-}
-
-
-function addMantaService(cli, opts, isMantav2, cb) {
+function ensureMantaDeploymentSvcAndInst(cli, opts, isMantav2, cb) {
     assert.object(cli, 'cli');
     assert.object(opts, 'opts');
     assert.bool(isMantav2, 'isMantav2');
@@ -117,11 +59,9 @@ function addMantaService(cli, opts, isMantav2, cb) {
     // master are "mantav2-*", images from the "mantav1" maintenance branches
     // are "mantav1-*".
     if (isMantav2) {
-        addServiceOpts.imgNames = ['mantav2-deployment'];
+        addServiceOpts.imgNames = manta.MANTAV2_IMG_NAMES;
     } else {
-        // Also include older "manta-deployment" images to support usage
-        // through the transition period.
-        addServiceOpts.imgNames = ['mantav1-deployment', 'manta-deployment'];
+        addServiceOpts.imgNames = manta.MANTAV1_IMG_NAMES;
     }
 
     if (opts.image) {
@@ -199,7 +139,7 @@ function do_manta(subcmd, opts, args, cb) {
     //
     // - TODO: support moving from a mantav1 deployment image to a mantav2
     //   deployment image (to begin migration to mantav1)
-    getMantav({sdcadm: self.sdcadm}, function (err, mantav) {
+    manta.getMantav(self.sdcadm, function (err, mantav) {
         self.log.debug({mantav: mantav, err: err}, 'getMantav');
         if (err) {
             cb(err);
@@ -211,7 +151,7 @@ function do_manta(subcmd, opts, args, cb) {
             cb(new VError('there is currently a mantav1 SAPI application, ' +
                 'migrating to mantav2 is not yet supported'));
         } else {
-            addMantaService(self, opts, isMantav2, cb);
+            ensureMantaDeploymentSvcAndInst(self, opts, isMantav2, cb);
         }
     });
 }
@@ -305,6 +245,4 @@ do_manta.logToFile = true;
 
 // --- exports
 
-module.exports = {
-    do_manta: do_manta
-};
+module.exports = do_manta;

--- a/lib/post-setup/index.js
+++ b/lib/post-setup/index.js
@@ -39,6 +39,8 @@ function PostSetupCLI(top) {
         helpSubcmds: [
             'help',
             { group: 'General Setup', unmatched: true },
+            { group: 'Manta Setup' },
+            'manta',
             { group: 'Development/Testing-only Setup' },
             'dev-headnode-prov',
             'dev-sample-data'
@@ -82,6 +84,8 @@ PostSetupCLI.prototype.do_prometheus = require('./prometheus').do_prometheus;
 PostSetupCLI.prototype.do_grafana = require('./grafana').do_grafana;
 PostSetupCLI.prototype.do_firewall_logger_agent =
     require('./firewall-logger-agent').do_firewall_logger_agent;
+
+PostSetupCLI.prototype.do_manta = require('./manta').do_manta;
 
 // --- exports
 

--- a/lib/post-setup/index.js
+++ b/lib/post-setup/index.js
@@ -85,7 +85,7 @@ PostSetupCLI.prototype.do_grafana = require('./grafana').do_grafana;
 PostSetupCLI.prototype.do_firewall_logger_agent =
     require('./firewall-logger-agent').do_firewall_logger_agent;
 
-PostSetupCLI.prototype.do_manta = require('./manta').do_manta;
+PostSetupCLI.prototype.do_manta = require('./do_manta');
 
 // --- exports
 

--- a/lib/post-setup/manta.js
+++ b/lib/post-setup/manta.js
@@ -197,11 +197,8 @@ function do_manta(subcmd, opts, args, cb) {
     // Ensure the current "mantav" (manta major version), if any, matches the
     // manta version of the deployment image we are being asked to setup.
     //
-    // - TODO: When 'sdcadm up manta' supports using the mantav1-/mantav2-
-    //   images (TRITON-1981) and EnsureMantaDeploymentGzLinksProcedure, then
-    //   error out in favour of using 'sdcadm up manta'.
     // - TODO: support moving from a mantav1 deployment image to a mantav2
-    //   deployment image (to being migration to mantav1)
+    //   deployment image (to begin migration to mantav1)
     getMantav({sdcadm: self.sdcadm}, function (err, mantav) {
         self.log.debug({mantav: mantav, err: err}, 'getMantav');
         if (err) {

--- a/lib/post-setup/manta.js
+++ b/lib/post-setup/manta.js
@@ -1,0 +1,313 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2019 Joyent, Inc.
+ */
+
+/*
+ * The 'sdcadm post-setup manta' CLI subcommand.
+ *
+ * This is used to bootstrap a Manta (mantav1 or mantav2) installation by
+ * creating the "manta" service on the "sdc" SAPI application.
+ *
+ * Note: eventually this will also be the command to convert from a mantav1
+ * deployment zone to a mantav2 deployment zone -- beginning the migration
+ * of an existing mantav1 to mantav2.
+ */
+
+const assert = require('assert-plus');
+const VError = require('verror');
+
+const AddServiceProcedure = require('../procedures/add-service')
+    .AddServiceProcedure;
+const EnsureMantaDeploymentGzLinksProcedure =
+    require('../procedures/ensure-manta-deployment-gz-links')
+    .EnsureMantaDeploymentGzLinksProcedure;
+const errors = require('../errors');
+const runProcs = require('../procedures').runProcs;
+
+
+// ---- internal support functions
+
+// Dev Note: We cannot use `sdcadm.getApp` because we must use
+// `include_master=true` for multi-DC manta.
+function getMantaApp(sapi, cb) {
+    sapi.listApplications({
+        name: 'manta',
+        include_master: 'true'
+    }, function (err, apps) {
+        if (err) {
+            cb(new errors.SDCClientError(err, 'sapi'));
+            return;
+        }
+
+        assert.ok(apps.length <= 1, 'zero or one "manta" SAPI apps');
+        if (apps.length === 0) {
+            cb(null, null);
+        } else {
+            cb(null, apps[0]);
+        }
+    });
+}
+
+// Get the current "mantav", the major version of the current Manta.
+//
+// This is one of three possible values:
+// - `null` - There is no "manta" SAPI app in this region (set of linked DCs,
+//   https://github.com/joyent/sdc-sapi/blob/master/docs/index.md#multi-dc-mode)
+// - `1` - Either the `$mantaApp.metadata.MANTAV` is set to the number 1, or
+//   it is not set.
+// - `2` - `$mantaApp.metadata.MANTAV` is set to the number 2.
+//
+// Any other value results in this calling back with an error.
+function getMantav(args, cb) {
+    assert.object(args, 'args');
+    assert.object(args.sdcadm, 'args.sdcadm');
+    assert.func(cb, 'cb');
+
+    getMantaApp(args.sdcadm.sapi, function (err, app) {
+        if (err) {
+            cb(err);
+        } else if (!app) {
+            cb(null, null);
+        } else {
+            let mantav = app.metadata.mantav;
+            if (mantav === undefined || mantav === 1) {
+                cb(null, 1);
+            } else if (mantav === 2) {
+                cb(null, 2);
+            } else {
+                cb(new VError(
+                    'invalid "metadata.MANTAV" on SAPI application %s ' +
+                        '(manta), must be 1, 2, or undefined: %s',
+                    app.uuid,
+                    JSON.stringify(mantav)));
+            }
+        }
+    });
+}
+
+
+function addMantaService(cli, opts, isMantav2, cb) {
+    assert.object(cli, 'cli');
+    assert.object(opts, 'opts');
+    assert.bool(isMantav2, 'isMantav2');
+    assert.func(cb, 'cb');
+
+    const addServiceOpts = {
+        svcName: 'manta',
+        packageName: 'sdc_1024',
+        // The manta0 zone instance must be on the headnode. We could look that
+        // up (`sdc-cnapi /servers?headnode=true | json -H 0.uuid`) or rely on
+        // the `AddServiceProcedure` behaviour of defaulting to the current
+        // server. We do the later (sdcadm is run on the headnode).
+        //    server: ...,
+        networks: [
+            {name: 'admin'},
+            {name: 'external', primary: true}
+        ],
+        firewallEnabled: true
+    };
+
+    // With the mantav1/mantav2 split there are new image names: images from
+    // master are "mantav2-*", images from the "mantav1" maintenance branches
+    // are "mantav1-*".
+    if (isMantav2) {
+        addServiceOpts.imgNames = ['mantav2-deployment']
+    } else {
+        // Also include older "manta-deployment" images to support usage
+        // through the transition period.
+        addServiceOpts.imgNames = ['mantav1-deployment', 'manta-deployment']
+    }
+
+    if (opts.image) {
+        addServiceOpts.image = opts.image;
+    }
+
+    if (opts.channel) {
+        addServiceOpts.channel = opts.channel;
+    }
+
+    if (isMantav2) {
+        cli.ui.info([
+            /* eslint-disable max-len */
+            'This will setup for a new Manta v2 deployment.',
+            '',
+            'This creates a new manta0 zone on the headnode which provides the',
+            'tooling for deploying and maintaining a Manta installation. After this',
+            'step is complete, follow the Manta Operator Guide to deploy Manta:',
+            '    https://joyent.github.io/manta/#deploying-manta'
+            /* eslint-enable */
+        ].join('\n'));
+    } else {
+        cli.ui.info([
+            /* eslint-disable max-len */
+            'This will setup for a new Manta v1 deployment.',
+            '',
+            'Note that mantav1 is no longer the latest version of Manta.',
+            'See the following for information on mantav1 vs mantav2:',
+            '    https://github.com/joyent/manta/blob/master/docs/mantav2.md',
+            '',
+            'This creates a new manta0 zone on the headnode which provides the',
+            'tooling for deploying and maintaining a Manta installation. After this',
+            'step is complete, follow the Manta Operator Guide to deploy Manta:',
+            '    https://github.com/joyent/manta/blob/mantav1/docs/operator-guide.md'
+            /* eslint-enable */
+        ].join('\n'));
+    }
+
+    runProcs({
+        log: cli.log,
+        procs: [
+            new AddServiceProcedure(addServiceOpts),
+            new EnsureMantaDeploymentGzLinksProcedure()
+        ],
+        sdcadm: cli.sdcadm,
+        ui: cli.ui,
+        dryRun: opts.dry_run,
+        skipConfirm: opts.yes
+    }, cb);
+}
+
+
+// ---- the cli subcommand
+
+function do_manta(subcmd, opts, args, cb) {
+    const self = this;
+    if (opts.help) {
+        this.do_help('help', {}, [subcmd], cb);
+        return;
+    } else if (args.length > 0) {
+        cb(new errors.UsageError('too many args: ' + args));
+        return;
+    }
+
+    let isMantav2 = true;
+    if (opts.mantav1 && opts.mantav2) {
+        cb(new errors.UsageError('cannot use both --mantav1 and --mantav2'));
+        return;
+    } else if (opts.mantav1) {
+        isMantav2 = false;
+    }
+
+    // Ensure the current "mantav" (manta major version), if any, matches the
+    // manta version of the deployment image we are being asked to setup.
+    //
+    // - TODO: When 'sdcadm up manta' supports using the mantav1-/mantav2-
+    //   images (TRITON-1981) and EnsureMantaDeploymentGzLinksProcedure, then
+    //   error out in favour of using 'sdcadm up manta'.
+    // - TODO: support moving from a mantav1 deployment image to a mantav2
+    //   deployment image (to being migration to mantav1)
+    getMantav({sdcadm: self.sdcadm}, function (err, mantav) {
+        self.log.debug({mantav: mantav, err: err}, 'getMantav');
+        if (err) {
+            cb(err);
+            return;
+        } else if (mantav === 2 && !isMantav2) {
+            cb(new VError('there is currently a mantav2 SAPI application, ' +
+                'cannot downgrade to mantav1'));
+        } else if (mantav === 1 && isMantav2) {
+            cb(new VError('there is currently a mantav1 SAPI application, ' +
+                'migrating to mantav2 is not yet supported'));
+        } else {
+            addMantaService(self, opts, isMantav2, cb);
+        }
+    });
+};
+
+do_manta.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['yes', 'y'],
+        type: 'bool',
+        help: 'Answer yes to all confirmations.'
+    },
+    {
+        names: ['dry-run', 'n'],
+        type: 'bool',
+        help: 'Do a dry-run.'
+    },
+    {
+        group: 'Manta version selection (by default mantav2)'
+    },
+    {
+        names: ['mantav1'],
+        type: 'bool',
+        help: 'If given, the Manta deployment zone will setup for a ' +
+            '*mantav1* deployment. Specifically this means using "mantav1-*" ' +
+            'images. See ' +
+            '<https://github.com/joyent/manta/blob/master/docs/mantav2.md> ' +
+            'for information on mantav1 vs mantav2.'
+    },
+    {
+        names: ['mantav2'],
+        type: 'bool',
+        help: 'If given or if no "--mantavN" option is given, the Manta ' +
+            'deployment zone will setup for a *mantav2* deployment. ' +
+            'Specifically this means using "mantav2-*" images. See ' +
+            '<https://github.com/joyent/manta/blob/master/docs/mantav2.md> ' +
+            'for information on mantav1 vs mantav2.'
+    },
+    {
+        group: 'Image selection (by default latest image on default ' +
+            'channel)'
+    },
+    {
+        names: ['image', 'i'],
+        type: 'string',
+        help: 'Specifies which image to use for the first instance. ' +
+            'Use "latest" (the default) for the latest available on ' +
+            'updates.joyent.com, "current" for the latest image already ' +
+            'in the datacenter (if any), or an image UUID or version.'
+    },
+    {
+        names: ['channel', 'C'],
+        type: 'string',
+        help: 'The updates.joyent.com channel from which to fetch the ' +
+            'image. See `sdcadm channel get` for the default channel.'
+    }
+
+];
+
+do_manta.help = [
+    /* eslint-disable max-len */
+    'Create the "manta" deployment zone to begin a Manta installation',
+    '',
+    'Usage:',
+    '     {{name}} manta',
+    '',
+    '{{options}}',
+    'This command handles the first step in deploying Manta: creating the manta',
+    'deployment zone.',
+    '    https://joyent.github.io/manta/#deploying-manta',
+    '',
+    'By default this will setup for a *mantav2* deployment. Use the "--mantav1"',
+    'option to setup for a mantav1 deployment. See the following for details on',
+    'mantav1 vs mantav2:',
+    '   https://github.com/joyent/manta/blob/master/docs/mantav2.md',
+    '',
+    'Note: Eventually this command will support the first step in converting',
+    'a mantav1 deployment to a mantav2 deployment. However this is not yet',
+    'supported.'
+    /* eslint-enable */
+].join('\n');
+
+do_manta.helpOpts = {
+    maxHelpCol: 19
+};
+
+do_manta.logToFile = true;
+
+// --- exports
+
+module.exports = {
+    do_manta: do_manta
+};

--- a/lib/post-setup/manta.js
+++ b/lib/post-setup/manta.js
@@ -117,11 +117,11 @@ function addMantaService(cli, opts, isMantav2, cb) {
     // master are "mantav2-*", images from the "mantav1" maintenance branches
     // are "mantav1-*".
     if (isMantav2) {
-        addServiceOpts.imgNames = ['mantav2-deployment']
+        addServiceOpts.imgNames = ['mantav2-deployment'];
     } else {
         // Also include older "manta-deployment" images to support usage
         // through the transition period.
-        addServiceOpts.imgNames = ['mantav1-deployment', 'manta-deployment']
+        addServiceOpts.imgNames = ['mantav1-deployment', 'manta-deployment'];
     }
 
     if (opts.image) {
@@ -217,7 +217,7 @@ function do_manta(subcmd, opts, args, cb) {
             addMantaService(self, opts, isMantav2, cb);
         }
     });
-};
+}
 
 do_manta.options = [
     {

--- a/lib/procedures/add-service.js
+++ b/lib/procedures/add-service.js
@@ -332,7 +332,9 @@ AddServiceProcedure.prototype.prepare = function addServicePrepare(opts, cb) {
         if (!self.svc ||
             self.needToDownloadImg ||
             self.svc.params.image_uuid !== self.svcImg.uuid ||
-            !self.svcInst) {
+            !self.svcInst ||
+            (self.svcInsts.length === 1 &&
+             self.svcVm.image_uuid !== self.svcImg.uuid)) {
             nothingToDo = false;
         }
         cb(null, nothingToDo);
@@ -365,8 +367,22 @@ AddServiceProcedure.prototype.summarize = function addServiceSummarize() {
     }
 
     if (!self.svcInst) {
-        out.push(sprintf('create "%s" service instance on server "%s"',
-            self.svcName, self.serverUuid));
+        out.push(sprintf('create "%s" service instance on server %s\n' +
+                '    with image %s (%s@%s)',
+            self.svcName,
+            self.serverUuid,
+            self.svcImg.uuid,
+            self.svcImg.name,
+            self.svcImg.version));
+    } else if (self.svcInsts.length === 1 &&
+            self.svcVm.image_uuid !== self.svcImg.uuid) {
+        out.push(sprintf('reprovision instance %s (%s)\n' +
+                '    with image %s (%s@%s)',
+            self.svcInst.uuid,
+            self.svcInst.params.alias || '<alias not set>',
+            self.svcImg.uuid,
+            self.svcImg.name,
+            self.svcImg.version));
     }
 
     return out.join('\n');
@@ -456,15 +472,6 @@ AddServiceProcedure.prototype.execute = function addServiceExecute(opts, cb) {
 
             function createInst(_, next) {
                 if (self.svcInst) {
-                    if (self.svcInsts.length === 1) {
-                        ui.info('Not creating an instance: there is ' +
-                            'already one %s instance (VM %s)',
-                            self.svcName, self.svcInst.params.alias);
-                    } else {
-                        ui.info('Not creating an instance: there are ' +
-                            'already %d %s instances',
-                            self.svcInsts.length, self.svcName);
-                    }
                     next();
                     return;
                 }
@@ -486,8 +493,53 @@ AddServiceProcedure.prototype.execute = function addServiceExecute(opts, cb) {
                     ui.info('Created VM %s (%s)', inst.uuid,
                         inst.params.alias);
                     self.svcInst = inst;
+                    self.createdSvcInst = true;
                     next();
                 });
+            },
+
+            // We don't want to get into handling updates of multiple (possibly
+            // many) instances, because `sdcadm up` is better equipped to do
+            // that. However, for the common case where there is a single
+            // instance of the service, it is useful to have the result of
+            // a re-run of `sdcadm post-setup $service` be a running instance
+            // using the specified image version.
+            function reprovisionSingleInst(_, next) {
+                if (self.createdSvcInst) {
+                    // Just created the instance above.
+                    next();
+                    return;
+                } else if (self.svcInst.image_uuid === self.svcImg.uuid) {
+                    // The instance has the desired image (assuming likewise
+                    // for other instances if there are any).
+                    next();
+                    return;
+                } else if (self.svcInsts.length > 1) {
+                    ui.info('Not reprovisioning multiple (%d) %s instances, ' +
+                            'use "sdcadm up %s@%s"',
+                        self.svcInsts.length,
+                        self.svcName,
+                        self.svcName,
+                        self.svcImg.uuid);
+                    next();
+                    return;
+                }
+
+                ui.info('Reprovisioning instance "%s" (%s)',
+                    self.svcInst.uuid, self.svcInst.params.alias);
+                sdcadm.sapi.reprovisionInstance(
+                    self.svcInst.uuid,
+                    self.svcImg.uuid,
+                    function reprovisionedCb(err) {
+                        if (err) {
+                            next(new errors.SDCClientError(err, 'sapi'));
+                            return;
+                        }
+                        ui.info('Reprovisioned instance "%s" (%s)',
+                            self.svcInst.uuid, self.svcInst.params.alias);
+                        next();
+                    }
+                );
             }
 
         ]}, cb);

--- a/lib/sdcadm.js
+++ b/lib/sdcadm.js
@@ -39,6 +39,7 @@ var common = require('./common');
 var svcadm = require('./svcadm');
 var errors = require('./errors');
 var lock = require('./locker').lock;
+var manta = require('./manta');
 var pkg = require('../package.json');
 var procedures = require('./procedures');
 
@@ -1363,12 +1364,17 @@ function imgNamesFromSvcName(svcName, cb) {
     assert.func(cb, 'cb');
 
     var self = this;
-    var imgNames = self.config.imgNamesFromSvcName[svcName];
-    assert.optionalArrayOfString(imgNames, 'imgNames');
-    if (!imgNames) {
-        cb(null, null);
+
+    if (svcName === 'manta') {
+        manta.getImgNames(self, cb);
     } else {
-        cb(null, imgNames);
+        var imgNames = self.config.imgNamesFromSvcName[svcName];
+        assert.optionalArrayOfString(imgNames, 'imgNames');
+        if (!imgNames) {
+            cb(null, null);
+        } else {
+            cb(null, imgNames);
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a Triton Data Center",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Also: TRITON-1981 update sdcadm to get the correct manta-deployment image

This adds 'sdcadm post-setup manta' to create the manta deployment zone
to start a Manta deployment. It provides a '--mantav1' to setup a mantav1,
but defaults to mantav2. It handles using the correct 
"manta{,v1,v2}-deployment" image and ensuring that one does not mix a mantav1
deployment image with an existing mantav2 deployment, and vice versa.

The Manta Operator Guide will separately be updated to point to this instead of
/usbkey/scripts/setup_manta_zone.sh

Other changes:
- Improve AddServiceProcedure to handle reprovisioning the single inst
  on a re-run if the image has changed. Before it wouldn't do this and
  it was kind of subtle. This is very important for the 'manta' service
  because the image used decides if this is mantav1 or mantav2.