### PR TITLE
MANTA-5293 rebalancer-agent hotpatching (add GZ link to manta-hotpatch-rebalancer-agent tool)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 
 # sdcadm Changelog
 
+## 1.35.0
+
+- MANTA-5293 add GZ link to 'manta-hotpatch-rebalancer-agent' tool in the
+  manta-deployment zone (when updating or deploying the 'manta' service).
+
 ## 1.34.0
 
 - MANTA-4811 'sdcadm post-setup manta' now supports migrating from a mantav1

--- a/lib/procedures/ensure-manta-deployment-gz-links.js
+++ b/lib/procedures/ensure-manta-deployment-gz-links.js
@@ -144,6 +144,7 @@ function execute(opts, cb) {
                 rmForceSync('/opt/smartdc/bin/manta-adm');
                 rmForceSync('/opt/smartdc/bin/manta-oneach');
                 rmForceSync('/opt/smartdc/bin/mantav2-migrate');
+                rmForceSync('/opt/smartdc/bin/manta-hotpatch-rebalancer-agent');
 
                 fs.writeFileSync(
                     '/opt/smartdc/bin/manta-login',
@@ -183,6 +184,18 @@ function execute(opts, cb) {
                         '#!/bin/bash',
                         'exec ' + zoneBaseDir + '/build/node/bin/node ' +
                             zoneBaseDir + '/bin/mantav2-migrate "$@"'
+                    ].join('\n'),
+                    {
+                        mode: 0o755
+                    }
+                );
+                fs.writeFileSync(
+                    '/opt/smartdc/bin/manta-hotpatch-rebalancer-agent',
+                    [
+                        '#!/bin/bash',
+                        'exec ' + zoneBaseDir + '/build/node/bin/node ' +
+                            zoneBaseDir +
+                            '/bin/manta-hotpatch-rebalancer-agent "$@"'
                     ].join('\n'),
                     {
                         mode: 0o755

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a Triton Data Center",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This change updates `sdcadm post-setup manta` and `sdcadm up manta` to create a symlink from the GZ to  the `manta-hotpatch-rebalancer-agent` tool that is deployed as part of the "manta" zone (i.e. the manta-deployment image built from sdc-manta.git).