### PR TITLE
Support Linux CNs

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1277,9 +1277,8 @@ Platform.prototype.assign = function assign(opts, callback) {
             });
         },
         function serverList(_, next) {
-            self.sdcadm.cnapi.listServers({
-                setup: true
-            }, function (err, recs) {
+            const listOpts = (opts.server) ? {} : { setup: true};
+            self.sdcadm.cnapi.listServers(listOpts, function (err, recs) {
                 if (err) {
                     next(err);
                     return;

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -116,7 +116,9 @@ function getPlatformsWithServers(cb) {
     var self = this;
     var latest;
 
-    self.sdcadm.cnapi.listPlatforms(function (err, platforms) {
+    self.sdcadm.cnapi.listPlatforms({
+        os: true
+    }, function (err, platforms) {
         if (err) {
             cb(new errors.SDCClientError(err, 'cnapi'));
             return;
@@ -127,7 +129,6 @@ function getPlatformsWithServers(cb) {
         }
 
         self._rawPlatforms = platforms;
-
         self.sdcadm.cnapi.listServers({
             setup: true
         }, function (er2, servers) {
@@ -197,14 +198,27 @@ function getPlatformsWithServers(cb) {
 // Get version for latest platform image installed into usbkey cache.
 // cb(err, latest)
 Platform.prototype.getLatestPlatformInstalled =
-function getLatestPlatformInstalled(cb) {
-    var self = this;
-    self.sdcadm.cnapi.listPlatforms(function (err, platforms) {
+function getLatestPlatformInstalled(os, cb) {
+    if (typeof (os) === 'function') {
+        cb = os;
+        os = 'smartos';
+    }
+    const self = this;
+    self.sdcadm.cnapi.listPlatforms({
+        os: true
+    }, function (err, platforms) {
         if (err) {
             cb(err);
             return;
         }
-        var latest = Object.keys(platforms).pop();
+        const latest = Object.keys(platforms).filter(function isLatest(pi) {
+            const isLatestP = typeof (platforms[pi].latest) !== 'undefined';
+            if (platforms[pi].os) {
+                return (platforms[pi].os === os && isLatestP);
+            } else {
+                return (isLatestP);
+            }
+        }).pop();
         cb(null, latest);
     });
 };
@@ -265,11 +279,14 @@ function createLatestLink(cb) {
 Platform.prototype.available = function available(opts, cb) {
     assert.object(opts, 'opts');
     assert.optionalString(opts.channel, 'opts.channel');
+    assert.optionalString(opts.os, 'opts.os');
 
-    var self = this;
+    const self = this;
 
-    var imgs;
-    vasync.pipeline({arg: {}, funcs: [
+    const context = {
+        imgs: []
+    };
+    vasync.pipeline({arg: context, funcs: [
         function ensureSdcApp(_, next) {
             self.sdcadm.ensureSdcApp({}, next);
         },
@@ -287,9 +304,20 @@ Platform.prototype.available = function available(opts, cb) {
                 next();
             });
         },
+        function getLatestLinuxInstalled(ctx, next) {
+            self.getLatestPlatformInstalled('linux', function (err2, latest) {
+                if (err2) {
+                    next(err2);
+                    return;
+                }
+                ctx.latestLinux = latest;
+                next();
+            });
+        },
         function getAvailableImages(ctx, next) {
-            var filter = {
-                name: 'platform'
+            const filter = {
+                name: (opts.os === 'smartos') ? 'platform' :
+                        opts.os === 'linux' ? 'platform-linux' : '~platform'
             };
             self.sdcadm.updates.listImages(filter, function (err, images) {
                 if (err) {
@@ -305,17 +333,22 @@ Platform.prototype.available = function available(opts, cb) {
                     return ({
                         version: img.version.split('-').pop(),
                         uuid: img.uuid,
-                        published_at: img.published_at
+                        published_at: img.published_at,
+                        os: img.os === 'other' ? 'smartos' : img.os
                     });
                 }).filter(function (i) {
-                    return (i.version > ctx.latest);
+                    if (i.os === 'smartos') {
+                        return (i.version > ctx.latest);
+                    } else {
+                        return (i.version > ctx.latestLinux);
+                    }
                 });
-                imgs = images;
+                ctx.imgs = images;
                 next(null);
             });
         }
     ]}, function pipeCb(pipeErr) {
-        cb(pipeErr, imgs);
+        cb(pipeErr, context.imgs);
     });
 };
 
@@ -346,7 +379,9 @@ Platform.prototype.list = function list(cb) {
                         current_platform: platforms[k].current_platform,
                         latest: platforms[k].latest || false,
                         default: (k === defPlatform),
-                        usb_key: (usbKeyPlatforms.indexOf(k) !== -1)
+                        usb_key: (usbKeyPlatforms.indexOf(k) !== -1),
+                        os: platforms[k].os === 'other' ?
+                            'smartos' : platforms[k].os
                     };
                 });
 
@@ -366,6 +401,7 @@ Platform.prototype.install = function install(opts, callback) {
     assert.object(opts, 'opts');
     assert.string(opts.image, 'opts.image');
     assert.optionalString(opts.channel, 'opts.channel');
+    assert.optionalString(opts.os, 'opts.os');
 
     var self = this;
     var localdir = '/var/tmp';
@@ -381,11 +417,19 @@ Platform.prototype.install = function install(opts, callback) {
     // TOOLS-1206: Keep track of when an error happened trying to find an
     // image in order to avoid same thing than for TOOLS-876
     var imgNotFoundError = false;
+    const opSystem = opts.os || 'smartos';
 
-    function findPlatformImageLatest(cb) {
-        var filter = {
-            name: 'platform'
+    // platform, platform-linux, ~platform for both
+    function findPlatformImageLatest(os, cb) {
+        if (typeof (os) === 'function') {
+            cb = os;
+            os = 'smartos';
+        }
+
+        const filter = {
+            name: os === 'smartos' ? 'platform' : 'platform-linux'
         };
+
         self.sdcadm.updates.listImages(filter, function (err, images) {
             if (err) {
                 imgNotFoundError = true;
@@ -402,8 +446,8 @@ Platform.prototype.install = function install(opts, callback) {
 
             cb();
         });
-        return;
     }
+
 
     function findPlatformImageByUuid(cb) {
         self.sdcadm.updates.getImage(opts.image, function (err, foundImage) {
@@ -417,9 +461,13 @@ Platform.prototype.install = function install(opts, callback) {
         });
     }
 
-    function findPlatformBySearching(cb) {
+    function findPlatformBySearching(os, cb) {
+        if (typeof (os) === 'function') {
+            cb = os;
+            os = 'smartos';
+        }
         var filter = {
-            name: 'platform',
+            name: os === 'smartos' ? 'platform' : 'platform-linux',
             version: '~' + '-' + opts.image
         };
         self.sdcadm.updates.listImages(filter, function (err, images) {
@@ -515,7 +563,7 @@ Platform.prototype.install = function install(opts, callback) {
             });
         },
         function findLatest(_, next) {
-            self.getLatestPlatformInstalled(function (err, platf) {
+            self.getLatestPlatformInstalled(opSystem, function (err, platf) {
                 if (err) {
                     next(err);
                     return;
@@ -527,7 +575,7 @@ Platform.prototype.install = function install(opts, callback) {
         // Make sure that if we install a new platform and Headnode is using
         // "latest", we really know what we're doing:
         function checkHeadnodePlatform(_, next) {
-            if (opts.yes) {
+            if (opts.yes || opSystem !== 'smartos') {
                 next();
                 return;
             }
@@ -556,7 +604,6 @@ Platform.prototype.install = function install(opts, callback) {
                         progress('Aborting platform install');
                         callback();
                         return;
-
                     }
                     next();
                 });
@@ -567,14 +614,16 @@ Platform.prototype.install = function install(opts, callback) {
             if (fs.existsSync(opts.image)) {
                 filepath = opts.image;
                 deleteOnFinish = false;
+                /* eslint-disable callback-return */
                 next();
+                /* eslint-enable callback-return */
             } else if (opts.image === 'latest') {
-                findPlatformImageLatest(next);
+                findPlatformImageLatest(opSystem, next);
             } else if (opts.image.match(
                 /([a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}?)/ig)) {
                 findPlatformImageByUuid(next);
             } else {
-                findPlatformBySearching(next);
+                findPlatformBySearching(opSystem, next);
             }
         },
 
@@ -584,7 +633,6 @@ Platform.prototype.install = function install(opts, callback) {
                 return;
             }
             progress('Checking latest Platform Image is already installed');
-
             var realVersion = image.version.split('-').pop();
             if (realVersion === latest) {
                 progress('Latest Platform Image already installed');
@@ -596,8 +644,10 @@ Platform.prototype.install = function install(opts, callback) {
 
         function downloadImage(_, next) {
             if (filepath) {
+                /* eslint-disable callback-return */
                 progress(format('Using platform file %s', filepath));
                 next();
+                /* eslint-enable callback-return */
             } else {
                 filepath = format('%s/platform-%s.tgz',
                                   localdir, image.version);
@@ -607,6 +657,10 @@ Platform.prototype.install = function install(opts, callback) {
         // TOOLS-1387: Check PI size vs available disk space before we try
         // to run the installer in order to fail early when possible.
         function checkPIUncompressedSize(ctx, next) {
+            if (opSystem !== 'smartos') {
+                next();
+                return;
+            }
             common.execFilePlus({
                 argv: ['/usr/bin/gzip', '-lq', filepath],
                 log: self.log
@@ -627,9 +681,17 @@ Platform.prototype.install = function install(opts, callback) {
             });
         },
         function mountUsbKey(_, next) {
+            if (opSystem !== 'smartos') {
+                next();
+                return;
+            }
             common.mountUsbKey(self.log, next);
         },
         function checkAvailableDiskSpace(ctx, next) {
+            if (opSystem !== 'smartos') {
+                next();
+                return;
+            }
             common.execFilePlus({
                 argv: ['/usr/bin/df', '-k', '/mnt/usbkey/os'],
                 log: self.log
@@ -660,9 +722,17 @@ Platform.prototype.install = function install(opts, callback) {
             executeInstallerFile(next);
         },
         function linkLatest(_, next) {
+            if (opSystem !== 'smartos') {
+                next();
+                return;
+            }
             self.createLatestLink(next);
         },
         function updateBootParams(_, next) {
+            if (opSystem !== 'smartos') {
+                next();
+                return;
+            }
             self.setDefaultBootPlatform(next);
         }
     ]}, function pipelineCb(err) {
@@ -704,7 +774,6 @@ Platform.prototype.install = function install(opts, callback) {
 
 Platform.prototype.setDefaultBootPlatform =
 function setDefaultBootPlatform(version, cb) {
-
     var self = this;
     var bootParams;
     var latestPlatform;
@@ -730,7 +799,9 @@ function setDefaultBootPlatform(version, cb) {
                 next();
                 return;
             }
-            self.sdcadm.cnapi.listPlatforms(function (err, platforms) {
+            self.sdcadm.cnapi.listPlatforms({
+                os: true
+            }, function (err, platforms) {
                 if (err) {
                     next(err);
                     return;
@@ -753,6 +824,19 @@ function setDefaultBootPlatform(version, cb) {
             }
             next();
         },
+        function verifyPlaformIsSmartOS(_, next) {
+            if (version === 'latest') {
+                next();
+                return;
+            }
+            if (self._rawPlatforms[version].os &&
+                self._rawPlatforms[version].os !== 'smartos') {
+                next(new errors.UsageError(
+                    'Only SmartOS Platform Images can be set as default'));
+                return;
+            }
+            next();
+        },
         function getLatestPlatformVersion(_, next) {
             if (version !== 'latest') {
                 next();
@@ -760,7 +844,13 @@ function setDefaultBootPlatform(version, cb) {
             }
             Object.keys(self._rawPlatforms).forEach(function (pl) {
                 if (self._rawPlatforms[pl].latest) {
-                    latestPlatform = pl;
+                    // First case: Old CNAPI, no `platform.os` value:
+                    if (!self._rawPlatforms[pl].os ||
+                        // Second case: New CNAPI, only "smartos" can be
+                        // used for default Platform Image
+                        self._rawPlatforms[pl].os === 'smartos') {
+                        latestPlatform = pl;
+                    }
                 }
             });
             next();
@@ -911,8 +1001,6 @@ Platform.prototype.deprecateLatest = function deprecateLatest(callback) {
 /**
  * Returns the relevant 8 digits of the CNAPI image version for the first
  * found CNAPI instance. (YYYYMMDD)
- * TODO (pedro): There are three modules using this for diferent services,
- * some refactoring and using it from lib/common.js would be great.
  */
 Platform.prototype.getCNAPIVersion = function getCNAPIVersion(callback) {
     var self = this;
@@ -975,6 +1063,8 @@ Platform.prototype.assign = function assign(opts, callback) {
     // need to store errors and report at end:
     var errs = [];
 
+    const wantLatest = (opts.platform === 'latest');
+
 
     /*
      * The booter(dhcpd) zone maintains a set of bootparams for each admin mac
@@ -1001,7 +1091,6 @@ Platform.prototype.assign = function assign(opts, callback) {
             function getAdminNicTags(_, next) {
                 self.sdcadm.napi.listNetworkPools({name: 'admin'},
                     function (err, pools) {
-
                     if (err) {
                         next(new errors.SDCClientError(err, 'napi'));
                         return;
@@ -1023,9 +1112,8 @@ Platform.prototype.assign = function assign(opts, callback) {
                     adminTags = pools[0].nic_tags_present;
                     next();
                 });
-
             },
-            function (_, next) {
+            function getAdminNics(_, next) {
                 if (adminTags.indexOf('admin') === -1) {
                     adminTags.push('admin');
                 }
@@ -1050,7 +1138,7 @@ Platform.prototype.assign = function assign(opts, callback) {
                     next();
                 });
             },
-            function (_, next) {
+            function overrideBootParamsInDhcpdZone(_, next) {
                 var script = format(
                     '#!/bin/bash\n' +
                     'export PATH=$PATH:/usr/bin:/usr/sbin:/opt/smartdc/bin/\n' +
@@ -1115,13 +1203,30 @@ Platform.prototype.assign = function assign(opts, callback) {
     }
 
     function assignForComputenode(server, cb) {
-        progress(
-            'updating computenode %s to %s',
-            server.uuid, opts.platform);
-
+        const currOS = self._rawPlatforms[server.current_platform] ?
+            self._rawPlatforms[server.current_platform].os :
+            'smartos';
+        var platf;
+        if (wantLatest) {
+            platf = currOS === 'smartos' ? opts.platform : opts.platformLinux;
+        } else {
+            const platformOs = self._rawPlatforms[opts.platform] ?
+                self._rawPlatforms[opts.platform].os :
+                'smartos';
+            if (currOS !== platformOs) {
+                var usageErr = new errors.UsageError(
+                    'Cannot change server Operating System without ' +
+                    'a Factory Reset');
+                errs.push(usageErr);
+                cb(usageErr);
+                return;
+            }
+            platf = opts.platform;
+        }
+        progress('updating computenode %s to %s', server.uuid, platf);
         progress('Setting cn boot params for %s', server.uuid);
         self.sdcadm.cnapi.setBootParams(server.uuid, {
-            platform: opts.platform
+            platform: platf
         }, {}, function (err) {
             if (err) {
                 errs.push(new errors.SDCClientError(err, 'cnapi'));
@@ -1132,7 +1237,7 @@ Platform.prototype.assign = function assign(opts, callback) {
 
     vasync.pipeline({funcs: [
         function findLatest(_, next) {
-            if (opts.platform !== 'latest') {
+            if (!wantLatest) {
                 next();
                 return;
             }
@@ -1145,8 +1250,24 @@ Platform.prototype.assign = function assign(opts, callback) {
                 next();
             });
         },
+        function findLatestLinux(_, next) {
+            if (!wantLatest) {
+                next();
+                return;
+            }
+            self.getLatestPlatformInstalled('linux', function (err, latest) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+                opts.platformLinux = latest;
+                next();
+            });
+        },
         function validatePlatform(_, next) {
-            self.sdcadm.cnapi.listPlatforms(function (err, platforms) {
+            self.sdcadm.cnapi.listPlatforms({
+                os: true
+            }, function (err, platforms) {
                 if (err) {
                     next(err);
                     return;
@@ -1197,7 +1318,6 @@ Platform.prototype.assign = function assign(opts, callback) {
                         self._usingLatest.push(server.uuid);
                     }
                 }
-
             });
 
             if (opts.server && !assignServers.length) {
@@ -1249,7 +1369,8 @@ Platform.prototype.assign = function assign(opts, callback) {
                 }
                 var updateErrs = [];
                 updated.forEach(function (u) {
-                    if (u.boot_platform !== opts.platform) {
+                    if (u.boot_platform !== opts.platform &&
+                        u.boot_platform !== opts.platformLinux) {
                         updateErrs.push(u.uuid);
                     }
                 });
@@ -1288,7 +1409,9 @@ Platform.prototype.usage = function (platform, cb) {
     var self = this;
     assert.string(platform, 'platform');
 
-    self.sdcadm.cnapi.listPlatforms(function (err, platforms) {
+    self.sdcadm.cnapi.listPlatforms({
+        os: true
+    }, function (err, platforms) {
         if (err) {
             cb(new errors.SDCClientError(err, 'cnapi'));
             return;
@@ -1343,7 +1466,6 @@ Platform.prototype.usage = function (platform, cb) {
 
 
 Platform.prototype.remove = function remove(opts, cb) {
-
     var self = this;
     assert.object(opts, 'opts');
     assert.optionalBool(opts.cleanup_cache, 'opts.cleanup_cache');
@@ -1525,6 +1647,12 @@ function do_install(subcmd, opts, args, cb) {
         return;
     }
 
+    if (opts.os && !opts.latest) {
+        cb(new errors.UsageError(
+            'Option --os can be used only with --latest'));
+        return;
+    }
+
     var options = {
         image: (opts.latest) ? 'latest' : args[0]
     };
@@ -1536,7 +1664,26 @@ function do_install(subcmd, opts, args, cb) {
     if (opts.yes) {
         options.yes = opts.yes;
     }
-    self.platform.install(options, cb);
+
+    // Given `--latest` and no `--os` means we want to install latest
+    // available Platform Image for both, SmartOS & Linux.
+    if (opts.latest && !opts.os) {
+        p('Installing latest SmartOS Platform Image');
+        self.platform.install(Object.assign({
+            os: 'smartos'
+        }, options), function (err) {
+            if (err) {
+                cb(err);
+                return;
+            }
+            p('Installing latest Linux Platform Image');
+            self.platform.install(Object.assign({
+                os: 'linux'
+            }, options), cb);
+        });
+    } else {
+        self.platform.install(options, cb);
+    }
 };
 
 PlatformCLI.prototype.do_install.help = (
@@ -1544,14 +1691,14 @@ PlatformCLI.prototype.do_install.help = (
     '\n' +
     'Please note that installing a new Platform Image will not\n' +
     'assign this image to any server. Install will download the\n' +
-    'image, put it on the head node USB key (/mnt/usbkey/os)\n' +
-    'and copy it back to the platform cache directory (/usbkey/os).\n' +
+    'image and put it on the platform cache directory (/usbkey/os).\n' +
     'The image is made available through CNAPI for later assignment.\n' +
     '\n' +
     'Usage:\n' +
     '     {{name}} install IMAGE-UUID\n' +
     '     {{name}} install PATH-TO-IMAGE\n' +
     '     {{name}} install --latest\n' +
+    '     {{name}} install --latest --os=linux\n' +
     '\n' +
     '{{options}}'
 );
@@ -1564,7 +1711,9 @@ PlatformCLI.prototype.do_install.options = [
     {
         names: ['latest'],
         type: 'bool',
-        help: 'Install the latest Platform Image from the update channel.'
+        help: 'Install the latest Platform Image from the update channel.' +
+            'When option --os is not present, it will install latest ' +
+            'available Platform Image for both "smartos" and "linux".'
     },
     {
         names: ['yes', 'y'],
@@ -1576,6 +1725,12 @@ PlatformCLI.prototype.do_install.options = [
         type: 'string',
         help: 'Use the given channel to fetch the image(s), even if it is ' +
             'not the default one.'
+    },
+    {
+        names: ['os'],
+        type: 'string',
+        help: 'Operating System for the Platform Image. Either "smartos" or ' +
+            '"linux". Only when "--latest" option is provided.'
     }
 ];
 
@@ -1824,7 +1979,7 @@ PlatformCLI.prototype.do_list.options = [
     {
         names: ['o'],
         type: 'string',
-        default: 'version,current_platform,boot_platform,latest,default',
+        default: 'version,current_platform,boot_platform,latest,default,os',
         help: 'Specify fields (columns) to output.',
         helpArg: 'field1,...'
     },
@@ -1858,6 +2013,7 @@ function do_usage(subcmd, opts, args, cb) {
     if (opts.plaform === 'help') {
         cb(new errors.UsageError(
         'Please use `sdcadm platform help usage` instead'));
+        return;
     }
 
     var columns = opts.o.trim().split(/\s*,\s*/g);
@@ -1895,7 +2051,6 @@ function do_usage(subcmd, opts, args, cb) {
             validFields: Object.keys(validFieldsMap)
         });
         cb();
-
     });
 };
 
@@ -1968,7 +2123,6 @@ function do_remove(subcmd, opts, args, cb) {
         // When --all is given we will not remove anything requiring the
         // --force flag:
         if (opts.all) {
-
             Object.keys(platforms).forEach(function (k) {
                 if (platforms[k].boot_platform.length === 0 &&
                     platforms[k].current_platform.length === 0) {
@@ -1979,7 +2133,6 @@ function do_remove(subcmd, opts, args, cb) {
             if (opts.keep_latest) {
                 opts.remove.splice(-opts.keep_latest);
             }
-
         } else {
             args.forEach(function (k) {
                 if (platforms[k] &&
@@ -2111,7 +2264,6 @@ PlatformCLI.prototype.do_avail = function do_avail(subcmd, opts, _args, cb) {
             cb();
             return;
         }
-
         if (!platforms.length) {
             self.sdcadm.getDefaultChannel(function (er2, channel) {
                 // Will not error due to channel not found
@@ -2140,7 +2292,9 @@ PlatformCLI.prototype.do_avail = function do_avail(subcmd, opts, _args, cb) {
                 validFields: Object.keys(validFieldsMap)
             });
 
+            /* eslint-disable callback-return */
             cb();
+            /* eslint-enable callback-return */
         }
     });
 };
@@ -2180,7 +2334,7 @@ PlatformCLI.prototype.do_avail.options = [
     {
         names: ['o'],
         type: 'string',
-        default: 'version,uuid,published_at',
+        default: 'version,uuid,published_at,os',
         help: 'Specify fields (columns) to output.',
         helpArg: 'field1,...'
     },
@@ -2197,6 +2351,13 @@ PlatformCLI.prototype.do_avail.options = [
         type: 'string',
         help: 'Use the given channel to fetch the image(s), even if it is ' +
             'not the default one.'
+    },
+    {
+        names: ['os'],
+        type: 'string',
+        help: 'Operating System for the Platform Image. Either "smartos" or ' +
+            '"linux". By default available Platform Images for both ' +
+            'Operating Systems will be listed.'
     }
 ];
 
@@ -2278,5 +2439,6 @@ PlatformCLI.prototype.do_set_default.logToFile = true;
 // --- exports
 
 module.exports = {
-    PlatformCLI: PlatformCLI
+    PlatformCLI: PlatformCLI,
+    Platform: Platform
 };

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -824,19 +824,6 @@ function setDefaultBootPlatform(version, cb) {
             }
             next();
         },
-        function verifyPlaformIsSmartOS(_, next) {
-            if (version === 'latest') {
-                next();
-                return;
-            }
-            if (self._rawPlatforms[version].os &&
-                self._rawPlatforms[version].os !== 'smartos') {
-                next(new errors.UsageError(
-                    'Only SmartOS Platform Images can be set as default'));
-                return;
-            }
-            next();
-        },
         function getLatestPlatformVersion(_, next) {
             if (version !== 'latest') {
                 next();
@@ -844,13 +831,7 @@ function setDefaultBootPlatform(version, cb) {
             }
             Object.keys(self._rawPlatforms).forEach(function (pl) {
                 if (self._rawPlatforms[pl].latest) {
-                    // First case: Old CNAPI, no `platform.os` value:
-                    if (!self._rawPlatforms[pl].os ||
-                        // Second case: New CNAPI, only "smartos" can be
-                        // used for default Platform Image
-                        self._rawPlatforms[pl].os === 'smartos') {
-                        latestPlatform = pl;
-                    }
+                    latestPlatform = pl;
                 }
             });
             next();
@@ -1173,6 +1154,18 @@ Platform.prototype.assign = function assign(opts, callback) {
     }
 
     function assignForHeadnode(server, cb) {
+        if (opts.platform !== 'latest') {
+            const platformOs = self._rawPlatforms[opts.platform] ?
+                self._rawPlatforms[opts.platform].os :
+                'smartos';
+            if (platformOs !== 'smartos') {
+                var usageErr = new errors.UsageError(
+                    'Headnode Operating System must be SmartOS');
+                errs.push(usageErr);
+                cb(usageErr);
+                return;
+            }
+        }
         vasync.pipeline({funcs: [
             function doSwitchPlatform(_, next) {
                 progress(
@@ -1213,7 +1206,7 @@ Platform.prototype.assign = function assign(opts, callback) {
             const platformOs = self._rawPlatforms[opts.platform] ?
                 self._rawPlatforms[opts.platform].os :
                 'smartos';
-            if (currOS !== platformOs) {
+            if (currOS !== platformOs && server.setup) {
                 var usageErr = new errors.UsageError(
                     'Cannot change server Operating System without ' +
                     'a Factory Reset');
@@ -2429,7 +2422,7 @@ PlatformCLI.prototype.do_set_default.options = [
     {
         names: ['latest'],
         type: 'bool',
-        help: 'Set default Platform Image to latest installed into USB key.'
+        help: 'Set default Platform Image to latest installed.'
     }
 ];
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "qlocker": "^1.0.1",
     "read": "1.0.5",
     "restify-clients": "1.4.0",
-    "sdc-clients": "12.2.0",
+    "sdc-clients": "13.0.3",
     "semver": "5.4.1",
     "strsplit": "1.0.0",
     "tabula": "1.9.0",
@@ -36,11 +36,12 @@
   },
   "devDependencies": {
     "marked-man": "0.1.4",
-    "eslint": "4.13.1",
+    "eslint": "4.19.1",
     "eslint-plugin-joyent": "~2.0.0",
     "mock-fs": "4.5.x",
     "tap": "^12.5.2",
-    "zkstream": "0.11.2"
+    "zkstream": "0.11.2",
+    "mockery": "^2.1.0"
   },
   "engines": {
     "node": ">=4.x"

--- a/test/unit/cli/do_platform.test.js
+++ b/test/unit/cli/do_platform.test.js
@@ -1,0 +1,1088 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2020 Joyent, Inc.
+ */
+
+'use strict';
+
+/*
+ * Mocking stuff, to be moved into its own file
+ */
+
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+
+const mockery = require('mockery');
+const tabula = require('tabula');
+
+// --- Mock base class
+
+function Mock() {
+    this.CALLS = {};
+    this.VALUES = {};
+}
+
+
+Mock.prototype._handle = function (name, args, cb) {
+    if (!this.CALLS.hasOwnProperty(name)) {
+        this.CALLS[name] = [];
+    }
+    this.CALLS[name].push(args);
+
+    if (!this.VALUES.hasOwnProperty(name)) {
+        return cb(new Error(name + ' mock error: no data specified'));
+    }
+
+    var nextVal = this.VALUES[name].shift();
+    if (!nextVal) {
+        return cb(new Error(name + ' mock error: no call data specified'));
+    }
+
+    var err = nextVal.err || null;
+    var res = nextVal.res;
+    if (!err && typeof (res) === 'undefined') {
+        return cb(new Error(name + ' mock error: no err or res specified'));
+    }
+
+    return cb(err, res);
+};
+
+// We don't need anything but exit code for platform testing:
+function MockSpawn(command, args, opts) {
+    this.command = command;
+    this.args = args;
+    this.opts = opts;
+
+    EventEmitter.call(this);
+    process.nextTick(() => {
+        this.emit('exit', 0);
+    });
+}
+
+util.inherits(MockSpawn, EventEmitter);
+
+function Mocks() {
+    this.mocks = Mocks.createMocks();
+
+    mockery.enable({ useCleanCache: true });
+    mockery.warnOnUnregistered(true);
+    [
+        './errors',
+        'util',
+        'tabula',
+        'assert',
+        'assert-plus',
+        'stream',
+        'vasync',
+        'extsprintf',
+        'cmdln',
+        'verror',
+        'dashdash',
+        'os',
+        'path',
+        'core-util-is',
+        'events',
+        'child_process',
+        'fs',
+        '../../../lib/platform'
+    ].forEach(function (mod) {
+        mockery.registerAllowable(mod);
+    });
+
+    mockery.registerMock('sdc-clients', this.mocks.sdcClients);
+    mockery.registerMock('./common', this.mocks.common);
+    mockery.registerMock('child_process', this.mocks.cp);
+    mockery.registerMock('fs', this.mocks.fs);
+}
+
+Mocks.createMocks = function () {
+    const mocks = {};
+
+    // NAPI:
+    mocks.napi = new Mock();
+    mocks.napi.listNetworkPools = function (params, cb) {
+        return this._handle('listNetworkPools', {
+            params: params
+        }, cb);
+    };
+
+    mocks.napi.listNics = function (params, opts, cb) {
+        if (typeof (opts) === 'function') {
+            cb = opts;
+            opts = {};
+        }
+        return this._handle('listNetworkPools', {
+            params: params
+        }, cb);
+    };
+
+    // CNAPI:
+    mocks.cnapi = new Mock();
+
+    mocks.cnapi.getBootParams = function (uuid, cb) {
+        return this._handle('getBootParams', {
+            uuid: uuid
+        }, cb);
+    };
+
+    mocks.cnapi.setBootParams = function (uuid, params, opts, cb) {
+        if (typeof (opts) === 'function') {
+            cb = opts;
+            opts = {};
+        }
+        return this._handle('setBootParams', {
+            uuid: uuid,
+            params: params
+        }, cb);
+    };
+
+    mocks.cnapi.listPlatforms = function (opts, cb) {
+        return this._handle('listPlatforms', {
+            opts: opts
+        }, cb);
+    };
+
+    mocks.cnapi.listServers = function (opts, cb) {
+        return this._handle('listServers', {
+            opts: opts
+        }, cb);
+    };
+
+    mocks.cnapi.commandExecute =
+        function (server, script, params, cb) {
+        return this._handle('commandExecute', {
+            server: server,
+            script: script,
+            params: params
+        }, cb);
+    };
+
+    mocks.imgapi = new Mock();
+
+    mocks.imgapi.listImages = function (filters, cb) {
+        return this._handle('listImages', {
+            filters: filters
+        }, cb);
+    };
+
+    mocks.imgapi.getImage = function (uuid, cb) {
+        return this._handle('getImage', {
+            uuid: uuid
+        }, cb);
+    };
+
+    mocks.imgapi.getImageFile = function (uuid, filepath, cb) {
+        return this._handle('getImageFile', {
+            uuid: uuid,
+            filepath: filepath
+        }, cb);
+    };
+
+    // sdc-clients
+
+    mocks.sdcClients = {
+        CNAPI: function FakeCNAPI() { },
+        NAPI: function FakeNAPI() { },
+        IMGAPI: function FakeIMGAPI() {}
+    };
+
+    mocks.common = new Mock();
+
+    mocks.common.isUsbKeyMounted = function (log, cb) {
+        return this._handle('isUsbKeyMounted', {
+            log: log
+        }, cb);
+    };
+
+    mocks.common.mountUsbKey = function (log, cb) {
+        return this._handle('mountUsbKey', {
+            log: log
+        }, cb);
+    };
+
+    mocks.common.unmountUsbKey = function (log, cb) {
+        return this._handle('unmountUsbKey', {
+            log: log
+        }, cb);
+    };
+
+    mocks.common.execFilePlus = function (args, cb) {
+        return this._handle('execFilePlus', {
+            args: args
+        }, cb);
+    };
+
+    mocks.common.sortArrayOfObjects = tabula.sortArrayOfObjects;
+    mocks.common.indent = console.log;
+    mocks.common.promptYesNo = function (_opts, cb) {
+        cb();
+    };
+
+    mocks.cp = {
+        spawn: function (cmd, args, opts) {
+            return (new MockSpawn(cmd, args, opts));
+        }
+    };
+
+    mocks.fs = {
+        unlink: function (_filepath, cb) {
+            return cb(null);
+        },
+        existsSync: function (_filepath) {
+            return false;
+        }
+    };
+
+    return mocks;
+};
+
+/*
+ * Real Platform testing goes here
+ */
+const jsprim = require('jsprim');
+const testutil = require('../testutil');
+const tap = require('tap');
+const log = testutil.createBunyanLogger(tap);
+
+
+// Note this is *intentionally* a list of platforms containing some possible
+// 'errors', like Platform Versions which lack any OS and should be ignored.
+const PLATFORMS_LIST = {
+    '20200304T133736Z': {
+        'os': 'smartos'
+    },
+    '20200310T072029Z': {
+        'os': 'linux'
+    },
+    '20200310T172203Z': {},
+    '20200313T113022Z': {
+        'os': 'smartos'
+    },
+    '20200313T161129Z': {
+        'os': 'linux',
+        'latest': true
+    },
+    '20200317T114808Z': {
+        'os': 'smartos',
+        'latest': true
+    }
+};
+
+
+const IMGADM_LIST_SMARTOS = [
+    {
+        'v': 2,
+        'uuid': 'f9b3caf0-c217-46af-8692-147d44de85c6',
+        'name': 'platform',
+        'version': 'master-20200304T133736Z',
+        'published_at': '2020-03-04T16:23:09.800Z',
+        'os': 'smartos'
+    },
+    {
+        'v': 2,
+        'uuid': '7cb03032-fa99-48c9-af81-9aed97d76996',
+        'name': 'platform',
+        'version': 'master-20200313T113022Z',
+        'published_at': '2020-03-13T14:21:06.384Z',
+        'os': 'smartos'
+    },
+    {
+        'v': 2,
+        'uuid': 'eb38fd9d-e367-4587-873b-22917949907b',
+        'name': 'platform',
+        'version': 'master-20200320T115353Z',
+        'published_at': '2020-03-20T14:39:50.627Z',
+        'os': 'smartos'
+    }
+];
+
+const IMGADM_LIST_LINUX = [
+    {
+        'v': 2,
+        'uuid': '73d040d0-9606-4074-99c9-9299d9273d17',
+        'name': 'platform-linux',
+        'version': 'master-20200310T072029Z',
+        'published_at': '2020-03-10T16:23:09.800Z',
+        'os': 'linux'
+    },
+    {
+        'v': 2,
+        'uuid': '5da3f259-7f80-4897-82df-f120935fcccf',
+        'name': 'platform-linux',
+        'version': 'master-20200313T161129Z',
+        'published_at': '2020-03-13T14:21:06.384Z',
+        'os': 'linux'
+    },
+    {
+        'v': 2,
+        'uuid': 'd198e28a-2d66-436d-a530-b26941a86d62',
+        'name': 'platform-linux',
+        'version': 'master-20200320T115353Z',
+        'published_at': '2020-03-20T14:39:50.627Z',
+        'os': 'linux'
+    }
+];
+
+const DEFAULT_BOOT_PARAMS = {
+    'platform': '20200304T133736Z',
+    'kernel_args': {
+        'rabbitmq': 'guest:guest:10.99.99.20:5672',
+        'smt_enabled': true,
+        'rabbitmq_dns': 'guest:guest:rabbitmq.coal.joyent.us:5672'
+    },
+    'kernel_flags': {},
+    'boot_modules': [],
+    'default_console': 'serial',
+    'serial': 'ttyb'
+};
+
+const SERVER_LIST = [
+    {
+        uuid: '564d99da-f14e-94aa-d8b9-18e5c9d50ba6',
+        hostname: 'headnode',
+        current_platform: '20200304T133736Z',
+        boot_platform: '20200313T113022Z',
+        headnode: true
+    },
+    {
+        uuid: '564d98bb-68c2-7688-1b89-cbe1ad480216',
+        hostname: 'smartoscn',
+        current_platform: '20200304T133736Z',
+        boot_platform: '20200313T113022Z',
+        headnode: false
+    },
+    {
+        uuid: '564d7287-6210-cfdc-9cf9-c3600aec8187',
+        hostname: 'linuxcn',
+        current_platform: '20200310T072029Z',
+        boot_platform: '20200313T161129Z',
+        headnode: false
+    }
+];
+
+const CNAPI_IMG = {
+    'v': 2,
+    'uuid': '7a0429e7-de28-45ea-9e17-afd048ec0da8',
+    'owner': '930896af-bf8c-48d4-885c-6573a94b1853',
+    'name': 'cnapi',
+    'version': 'master-20200310T190435Z-g4869d31',
+    'published_at': '2020-03-10T19:08:26.567Z'
+};
+
+// We really need the macs only.
+const SERVERS_NICS = [
+    {
+        'belongs_to_type': 'server',
+        'belongs_to_uuid': '564d7287-6210-cfdc-9cf9-c3600aec8187',
+        'mac': '00:0c:29:ec:81:87',
+        'ip': '10.99.99.40',
+        'mtu': 1500,
+        'netmask': '255.255.255.0',
+        'nic_tag': 'admin',
+        'resolvers': [
+          '10.99.99.11'
+        ],
+        'vlan_id': 0,
+        'nic_tags_provided': [
+          'admin'
+        ]
+    },
+    {
+        'belongs_to_type': 'server',
+        'belongs_to_uuid': '564d98bb-68c2-7688-1b89-cbe1ad480216',
+        'mac': '00:0c:29:48:02:16',
+        'ip': '10.99.99.37',
+        'netmask': '255.255.255.0',
+        'nic_tag': 'admin',
+        'resolvers': [
+          '10.99.99.11'
+        ],
+        'vlan_id': 0,
+        'nic_tags_provided': [
+          'admin'
+        ]
+    },
+    {
+        'belongs_to_type': 'server',
+        'belongs_to_uuid': '564d99da-f14e-94aa-d8b9-18e5c9d50ba6',
+        'mac': '00:50:56:34:60:4c',
+        'primary': false,
+        'ip': '10.99.99.7',
+        'netmask': '255.255.255.0',
+        'nic_tag': 'admin',
+        'resolvers': [
+          '10.99.99.11'
+        ],
+        'vlan_id': 0,
+        'nic_tags_provided': [
+          'admin'
+        ]
+    }
+];
+
+tap.test('Platform list test', function (suite) {
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        getBootParams: [],
+        listServers: []
+    };
+
+    myMocks.mocks.common.VALUES = {
+        execFilePlus: [],
+        mountUsbKey: [],
+        unmountUsbKey: [],
+        isUsbKeyMounted: []
+    };
+
+    // This suite tests intentionally check each individual method
+    // invoked by Platform.listPlatforms before testing it so we can detect
+    // where are failures faster:
+    suite.test('getLatestPlatformInstalled', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        platf.getLatestPlatformInstalled(function (err, latest) {
+            t.ifError(err, 'error getting latest platform');
+            t.equal(latest, '20200317T114808Z', 'latest smartos platform');
+            platf.getLatestPlatformInstalled('linux', function (err2, linux) {
+                t.ifError(err2, 'error getting latest linux platform');
+                t.equal(linux, '20200313T161129Z', 'latest linux platform');
+                t.end();
+            });
+        });
+    });
+
+    suite.test('getDefaultBootPlatform', function (t) {
+        myMocks.mocks.cnapi.VALUES.getBootParams.push(
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) }
+        );
+        platf.getDefaultBootPlatform(function (err, defPlatf) {
+            t.ifError(err, 'error getting default boot platform');
+            t.equal(defPlatf, DEFAULT_BOOT_PARAMS.platform,
+                'default boot params platform');
+            t.end();
+        });
+    });
+
+    suite.test('getPlatformsWithServers', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) }
+        );
+        platf.getPlatformsWithServers(function (err, platforms) {
+            t.ifError(err, 'error getting platforms with servers');
+            t.equal(platforms['20200304T133736Z'].current_platform.length, 2,
+                'Current SmartOS Servers Platform');
+            t.equal(platforms['20200313T113022Z'].boot_platform.length, 2,
+                'SmartOS Servers Boot Platform');
+            t.equal(platforms['20200310T072029Z'].current_platform.length, 1,
+                'Current Linux Servers Platform');
+            t.equal(platforms['20200313T161129Z'].boot_platform.length, 1,
+                'Linux Servers Boot Platform');
+            t.end();
+        });
+    });
+
+    suite.test('listUSBKeyPlatforms', function (t) {
+        myMocks.mocks.common.VALUES.execFilePlus.push(
+            { res: '20200304t133736z\n20200313t113022z\n' }
+        );
+        myMocks.mocks.common.VALUES.isUsbKeyMounted.push(
+            { err: null, res: false }
+        );
+        myMocks.mocks.common.VALUES.mountUsbKey.push(
+            { err: null, res: true }
+        );
+        myMocks.mocks.common.VALUES.unmountUsbKey.push(
+            { err: null, res: true }
+        );
+        platf.listUSBKeyPlatforms(function (err, platfs) {
+            t.ifError(err, 'listUSBKeyPlatforms error');
+            t.ok(Array.isArray(platfs), 'expected listUSBKeyPlatforms array');
+            t.equal(platfs.length, 2, 'listUSBKeyPlatforms length');
+            t.end();
+        });
+    });
+
+    suite.test('list', function (t) {
+        myMocks.mocks.cnapi.VALUES.getBootParams.push(
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) }
+        );
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) }
+        );
+        myMocks.mocks.common.VALUES.execFilePlus.push(
+            { res: '20200304t133736z\n20200313t113022z\n' }
+        );
+        myMocks.mocks.common.VALUES.isUsbKeyMounted.push(
+            { err: null, res: false }
+        );
+        myMocks.mocks.common.VALUES.mountUsbKey.push(
+            { err: null, res: true }
+        );
+        myMocks.mocks.common.VALUES.unmountUsbKey.push(
+            { err: null, res: true }
+        );
+        platf.list(function (err, platforms) {
+            t.ifError(err, 'listPlatforms error');
+            t.ok(Array.isArray(platforms), 'expected list of platforms');
+            t.equal(Object.keys(PLATFORMS_LIST).length, platforms.length,
+                'expected platforms length');
+            platforms.forEach(function (p) {
+                if (p.os === 'smartos' && (
+                    p.boot_platform.some(function (s) {
+                        return s.hostname === 'headnode';
+                    }) || p.current_platform.some(function (s) {
+                        return s.hostname === 'headnode';
+                    }))) {
+                    t.ok(p.usb_key, 'Headnode SmartOS PI in USB Key');
+                } else {
+                    t.notOk(p.usb_key, 'Not in USB Key');
+                }
+            });
+            t.end();
+        });
+    });
+
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+
+    suite.end();
+});
+
+
+tap.test('Platform available test', function (suite) {
+    mockery.deregisterAll();
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi,
+            ensureSdcApp: function (_opts, cb) {
+                top.sdcadm.sdcApp = {};
+                cb();
+            },
+            updates: myMocks.mocks.imgapi
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        getBootParams: [],
+        listServers: []
+    };
+
+    myMocks.mocks.common.VALUES = {
+        execFilePlus: [],
+        mountUsbKey: [],
+        unmountUsbKey: [],
+        isUsbKeyMounted: []
+    };
+
+    myMocks.mocks.imgapi.VALUES = {
+        listImages: []
+    };
+
+    suite.test('platform avail (no os given)', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.imgapi.VALUES.listImages.push(
+            { res: [].concat(IMGADM_LIST_SMARTOS, IMGADM_LIST_LINUX) }
+        );
+        platf.available({}, function (err, platforms) {
+            t.ifError(err, 'Platform available error');
+            t.ok(Array.isArray(platforms), 'Updates platforms array');
+            t.equal(2, platforms.length, 'Expected two platforms avail');
+            t.end();
+        });
+    });
+
+    suite.test('platform avail (os=linux)', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.imgapi.VALUES.listImages.push(
+            { res: IMGADM_LIST_LINUX }
+        );
+        platf.available({os: 'linux'}, function (err, platforms) {
+            t.ifError(err, 'Platform available error');
+            t.ok(Array.isArray(platforms), 'Updates platforms array');
+            t.equal(1, platforms.length, 'Expected one platform avail');
+            t.equal('linux', platforms[0].os, 'Expected linux');
+            t.end();
+        });
+    });
+
+    suite.test('platform avail (os=smartos)', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.imgapi.VALUES.listImages.push(
+            { res: IMGADM_LIST_SMARTOS }
+        );
+        platf.available({os: 'smartos'}, function (err, platforms) {
+            t.ifError(err, 'Platform available error');
+            t.ok(Array.isArray(platforms), 'Updates platforms array');
+            t.equal(1, platforms.length, 'Expected one platform avail');
+            t.equal('smartos', platforms[0].os, 'Expected smartos');
+            t.end();
+        });
+    });
+
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+
+    suite.end();
+});
+
+
+tap.test('Platform assign test', function (suite) {
+    mockery.deregisterAll();
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi,
+            napi: myMocks.mocks.napi,
+            ensureSdcApp: function (_opts, cb) {
+                top.sdcadm.sdcApp = {};
+                cb();
+            },
+            updates: myMocks.mocks.imgapi,
+            getImgsForSvcVms: function (_opts, cb) {
+                myMocks.mocks.imgapi.getImage(CNAPI_IMG.uuid,
+                    function (err, img) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+
+                    cb(null, {
+                        imgs: [img]
+                    });
+                });
+            }
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        getBootParams: [],
+        setBootParams: [],
+        listServers: [],
+        commandExecute: []
+    };
+
+    myMocks.mocks.common.VALUES = {
+        execFilePlus: [],
+        mountUsbKey: [],
+        unmountUsbKey: [],
+        isUsbKeyMounted: []
+    };
+
+    myMocks.mocks.imgapi.VALUES = {
+        listImages: [],
+        getImage: []
+    };
+
+    myMocks.mocks.napi.VALUES = {
+        listNetworkPools: [ { res: [] }, { res: [] } ],
+        listNics: []
+    };
+
+    suite.test('Get CNAPI version test', function (t) {
+        myMocks.mocks.imgapi.VALUES.getImage.push({
+            res: jsprim.deepCopy(CNAPI_IMG)
+        });
+        platf.getCNAPIVersion(function (err, version) {
+            t.ifError(err, 'Get CNAPI version error');
+            t.equal(version, '20200310', 'CNAPI version');
+            t.end();
+        });
+    });
+
+    suite.test('Assign latest platform to all servers test', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) },
+            { res: jsprim.deepCopy(SERVER_LIST).map(function (s) {
+                if (s.hostname === 'linuxcn') {
+                    s.boot_platform = '20200313T161129Z';
+                } else {
+                    s.boot_platform = '20200317T114808Z';
+                }
+                return s;
+            }) }
+        );
+        myMocks.mocks.cnapi.VALUES.setBootParams.push(
+            { res: {} },
+            { res: {} },
+            { res: {} },
+            { res: {} }
+        );
+        myMocks.mocks.cnapi.VALUES.commandExecute.push(
+            { res: ['==> Mounting USB key',
+                    '/mnt/usbkey',
+                    '==> Updating Loader configuration',
+                    '==> Updating cnapi',
+                    '==> Unmounting USB Key',
+                    '==> Done!' ].join('\n') },
+            { res: 'Done!' }
+        );
+        myMocks.mocks.napi.VALUES.listNics.push(
+            { res: jsprim.deepCopy(SERVERS_NICS) }
+        );
+        myMocks.mocks.imgapi.VALUES.getImage.push({
+            res: jsprim.deepCopy(CNAPI_IMG)
+        });
+
+        myMocks.mocks.cnapi.VALUES.getBootParams.push(
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) },
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) }
+        );
+
+        myMocks.mocks.common.VALUES.execFilePlus.push(
+            { res: '\n' }
+        );
+        platf.assign({
+            all: true,
+            platform: 'latest'
+        }, function (err) {
+            t.ifError(err, 'assign platform error');
+            t.end();
+        });
+    });
+
+    suite.test('Assign wrong OS platform to setup server', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) }
+        );
+        platf.assign({
+            platform: '20200317T114808Z',
+            server: ['564d7287-6210-cfdc-9cf9-c3600aec8187']
+        }, function (err) {
+            t.ok(err, 'expected error');
+            t.ok(err.message, 'expected error message');
+            t.ok(/operating system/i.test(err.message),
+                'expected message contains OS');
+            t.ok(/factory reset/i.test(err.message),
+                'expected message contains factory reset');
+            t.end();
+        });
+    });
+
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+
+    suite.end();
+});
+
+
+tap.test('Platform usage', function (suite) {
+    mockery.deregisterAll();
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi,
+            napi: myMocks.mocks.napi,
+            ensureSdcApp: function (_opts, cb) {
+                top.sdcadm.sdcApp = {};
+                cb();
+            },
+            updates: myMocks.mocks.imgapi,
+            getImgsForSvcVms: function (_opts, cb) {
+                myMocks.mocks.imgapi.getImage(CNAPI_IMG.uuid,
+                    function (err, img) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+
+                    cb(null, {
+                        imgs: [img]
+                    });
+                });
+            }
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        listServers: []
+    };
+
+    suite.test('Platform Usage', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) }
+        );
+
+        platf.usage('20200304T133736Z', function (err, usageRows) {
+            t.ifError(err, 'platform usage error');
+            t.ok(Array.isArray(usageRows), 'Expected array of servers');
+            t.equal(2, usageRows.length, 'Expected 2 servers');
+            t.end();
+        });
+    });
+
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+
+    suite.end();
+});
+
+
+tap.test('Platform remove', function (suite) {
+    mockery.deregisterAll();
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi,
+            getImgsForSvcVms: function (_opts, cb) {
+                myMocks.mocks.imgapi.getImage(CNAPI_IMG.uuid,
+                    function (err, img) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+
+                    cb(null, {
+                        imgs: [img]
+                    });
+                });
+            }
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        getBootParams: [],
+        listServers: []
+    };
+
+    myMocks.mocks.common.VALUES = {
+        execFilePlus: [],
+        mountUsbKey: [],
+        unmountUsbKey: [],
+        isUsbKeyMounted: []
+    };
+
+    myMocks.mocks.imgapi.VALUES = {
+        listImages: [],
+        getImage: [],
+        getImageFile: []
+    };
+
+    suite.test('remove', function (t) {
+        myMocks.mocks.common.VALUES.isUsbKeyMounted.push(
+            { err: null, res: false }
+        );
+        myMocks.mocks.common.VALUES.mountUsbKey.push(
+            { err: null, res: true }
+        );
+        myMocks.mocks.common.VALUES.unmountUsbKey.push(
+            { err: null, res: true }
+        );
+        myMocks.mocks.common.VALUES.execFilePlus.push(
+            { res: '\n' },
+            { res: '\n' }
+        );
+        myMocks.mocks.imgapi.VALUES.getImage.push({
+            res: jsprim.deepCopy(CNAPI_IMG)
+        });
+
+        platf.remove({
+            cleanup_cache: true,
+            yes: true,
+            remove: ['20200317T114808Z']
+        }, function (err) {
+            t.ifError(err, 'platform remove error');
+            t.end();
+        });
+    });
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+    suite.end();
+});
+
+tap.test('Platform install', function (suite) {
+    mockery.deregisterAll();
+    const myMocks = new Mocks();
+    const top = {
+        sdcadm: {
+            log: log,
+            cnapi: myMocks.mocks.cnapi,
+            napi: myMocks.mocks.napi,
+            ensureSdcApp: function (_opts, cb) {
+                top.sdcadm.sdcApp = {};
+                cb();
+            },
+            updates: myMocks.mocks.imgapi,
+            getImgsForSvcVms: function (_opts, cb) {
+                myMocks.mocks.imgapi.getImage(CNAPI_IMG.uuid,
+                    function (err, img) {
+                    if (err) {
+                        cb(err);
+                        return;
+                    }
+
+                    cb(null, {
+                        imgs: [img]
+                    });
+                });
+            },
+            getDefaultChannel: function (cb) {
+                cb(null, 'dev');
+            }
+        },
+        log: log,
+        progress: tap.comment
+    };
+
+    const Platform = require('../../../lib/platform').Platform;
+    const platf = new Platform(top);
+
+    myMocks.mocks.cnapi.VALUES = {
+        listPlatforms: [],
+        getBootParams: [],
+        listServers: []
+    };
+
+    myMocks.mocks.imgapi.VALUES = {
+        listImages: [],
+        getImage: [],
+        getImageFile: []
+    };
+
+    myMocks.mocks.common.VALUES = {
+        execFilePlus: [],
+        mountUsbKey: [],
+        unmountUsbKey: [],
+        isUsbKeyMounted: []
+    };
+
+    suite.test('Platform install', function (t) {
+        myMocks.mocks.cnapi.VALUES.listPlatforms.push(
+            { res: jsprim.deepCopy(PLATFORMS_LIST) },
+            { res: jsprim.deepCopy(PLATFORMS_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.listServers.push(
+            { res: jsprim.deepCopy(SERVER_LIST) }
+        );
+        myMocks.mocks.cnapi.VALUES.getBootParams.push(
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) },
+            { res: jsprim.deepCopy(DEFAULT_BOOT_PARAMS) }
+        );
+        myMocks.mocks.imgapi.VALUES.listImages.push(
+            { res: IMGADM_LIST_SMARTOS }
+        );
+        myMocks.mocks.imgapi.VALUES.getImageFile.push(
+            { res: {} }
+        );
+        myMocks.mocks.common.VALUES.execFilePlus.push(
+            { res: '           178884278           310814720' +
+                '  42.4% /var/tmp/platform-master-20200324T020911Z.tar' },
+            { res: [ 'Filesystem           1024-blocks        Used   ' +
+                'Available Capacity  Mounted on',
+                '/dev/dsk/c1d0s2          3604862     3110440      ' +
+                '494422    87%    /mnt/usbkey' ].join('\n') }
+        );
+        myMocks.mocks.common.VALUES.isUsbKeyMounted.push(
+            { err: null, res: false }
+        );
+        myMocks.mocks.common.VALUES.mountUsbKey.push(
+            { err: null, res: true }
+        );
+        myMocks.mocks.common.VALUES.unmountUsbKey.push(
+            { err: null, res: true }
+        );
+
+        myMocks.mocks.imgapi.VALUES.getImage.push({
+            res: jsprim.deepCopy(CNAPI_IMG)
+        });
+
+        platf.install({
+            image: 'latest'
+        }, function (err) {
+            t.ifError(err, 'Install platform error');
+            t.end();
+        });
+    });
+
+    suite.test('teardown', function (t) {
+        mockery.disable();
+        t.end();
+    });
+
+    suite.end();
+});


### PR DESCRIPTION
- TRITON-1946 sdcadm platform needs to be OS aware
- TRITON-2092 sdcadm should allow setting Linux as default platform for new CNs
- TRITON-2092: Allow setting boot_platform for unsetup server using sdcadm