### PR TITLE
TRITON-2194 provisionTmpVm should include metadata object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,10 +5,14 @@
 -->
 
 <!--
-    Copyright 2020 Joyent, Inc.
+    Copyright 2021 Joyent, Inc.
 -->
 
 # sdcadm Changelog
+
+## 1.35.2
+
+- TRITON-2194 provisionTmpVm should include metadata object
 
 ## 1.35.1
 

--- a/lib/procedures/shared.js
+++ b/lib/procedures/shared.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2021 Joyent, Inc.
  */
 
 var path = require('path');
@@ -529,7 +529,8 @@ function provisionTmpVm(arg, next) {
     sdcadm.sapi.createInstance(svc.uuid, {
         params: {
             alias: arg.tmpAlias,
-            server_uuid: arg.server_uuid
+            server_uuid: arg.server_uuid,
+            metadata: arg.metadata || {}
         }
     }, function (err, body) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a Triton Data Center",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "author": "Joyent (joyent.com)",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
I tested this by hot patching my sdcadm and upgrading moray while watching sapi instances to verify that the new instance was created with a metadata object.