### PR TITLE
TOOLS-2593 Add sdcadm experimental get-tritonadm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,10 +7,17 @@
 <!--
     Copyright 2021 Joyent, Inc.
     Copyright 2024 MNX Cloud, Inc.
-    Copyright 2025 Edgecast Cloud LLC.
+    Copyright 2026 Edgecast Cloud LLC.
 -->
 
 # sdcadm Changelog
+
+## 1.39.2
+
+- Add `sdcadm experimental get-tritonadm` to download and install the
+  `tritonadm` companion tool from the updates channel. Short-circuits
+  when the candidate image UUID matches the uuid recorded in
+  `/opt/triton/tritonadm/etc/version`.
 
 ## 1.39.1
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -88,6 +88,22 @@ image version (referencing git branch, date and git SHA). For example:
     [root@headnode (coal) ~]# sdcadm --version
     sdcadm 1.24.1 (release-20181220-20181220T050440Z-g382c6f1)
 
+#### (Experimental) Install tritonadm
+
+`tritonadm` is a companion tool distributed independently of sdcadm via
+the same updates channel. To fetch and install the latest image:
+
+    sdcadm experimental get-tritonadm --latest
+
+Or install a specific image UUID:
+
+    sdcadm experimental get-tritonadm IMAGE_UUID
+
+The command compares the candidate image UUID against the uuid recorded
+in `/opt/triton/tritonadm/etc/version` and short-circuits with "Already
+up-to-date" when they match. This command is experimental and subject
+to change.
+
 ### Step 4: (Optional) Download Triton images
 
 To reduce the downtime during upgrade, it's recommended to pre-download all

--- a/lib/cli/do_get_tritonadm.js
+++ b/lib/cli/do_get_tritonadm.js
@@ -1,0 +1,495 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2026 Edgecast Cloud LLC.
+ */
+'use strict';
+
+/*
+ * The 'sdcadm experimental get-tritonadm' CLI subcommand.
+ *
+ * Downloads a tritonadm image from the updates channel and executes its
+ * self-extracting installer. Short-circuits with "Already up-to-date"
+ * when the candidate image UUID matches the uuid recorded in
+ * /opt/triton/tritonadm/etc/version (KEY=VALUE format with keys:
+ * uuid, version, installed_at, source).
+ */
+
+var assert = require('assert-plus');
+var child_process = require('child_process');
+var exec = child_process.exec;
+var format = require('util').format;
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var vasync = require('vasync');
+
+var common = require('../common');
+var errors = require('../errors');
+
+
+var TRITONADM_VERSION_FILE = '/opt/triton/tritonadm/etc/version';
+var INSTALLER_DIR = '/var/tmp';
+var WRKDIR_BASE = '/var/sdcadm/tritonadm-installs';
+
+
+/*
+ * Parse the KEY=VALUE format used by /opt/triton/tritonadm/etc/version.
+ * Blank lines and lines starting with '#' are ignored. Each remaining
+ * line must contain an '='; the key is everything before the first '=',
+ * the value everything after (both trimmed).
+ */
+function parseVersionFile(content) {
+    assert.string(content, 'content');
+    var result = {};
+    var lines = content.split(/\r?\n/);
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (line === '' || line.charAt(0) === '#') {
+            continue;
+        }
+        var idx = line.indexOf('=');
+        if (idx === -1) {
+            continue;
+        }
+        var key = line.slice(0, idx).trim();
+        var value = line.slice(idx + 1).trim();
+        if (key) {
+            result[key] = value;
+        }
+    }
+    return result;
+}
+
+
+/*
+ * Read and parse the tritonadm version file. On ENOENT, or when the file
+ * has no `uuid=` entry, returns null (no tritonadm currently installed).
+ */
+function readInstalledVersion(filePath, cb) {
+    assert.string(filePath, 'filePath');
+    assert.func(cb, 'cb');
+    fs.readFile(filePath, 'utf8', function onRead(err, data) {
+        if (err) {
+            if (err.code === 'ENOENT') {
+                cb(null, null);
+                return;
+            }
+            cb(new errors.InternalError({
+                message: 'error reading tritonadm version file',
+                path: filePath,
+                cause: err
+            }));
+            return;
+        }
+        var parsed = parseVersionFile(data);
+        if (!parsed.uuid) {
+            cb(null, null);
+            return;
+        }
+        cb(null, parsed);
+    });
+}
+
+
+/*
+ * Pick the most recently published candidate. Matches the jq pipeline
+ * used by tools/install-tritonadm.sh and tritonadm's own self-update:
+ * sort_by(.published_at) | reverse | .[0].
+ */
+function pickLatest(candidates) {
+    assert.arrayOfObject(candidates, 'candidates');
+    if (candidates.length === 0) {
+        return undefined;
+    }
+    var sorted = candidates.slice().sort(function (a, b) {
+        if (a.published_at < b.published_at) {
+            return 1;
+        }
+        if (a.published_at > b.published_at) {
+            return -1;
+        }
+        return 0;
+    });
+    return sorted[0];
+}
+
+
+/*
+ * GetTritonadm engine. Orchestrates: ensureSdcApp, acquireLock,
+ * getDefaultChannel, read installed version, pick candidate by UUID or
+ * --latest, short-circuit on UUID match, download, create workdir, exec
+ * installer, release lock.
+ */
+function GetTritonadm(opts) {
+    assert.object(opts, 'opts');
+    assert.object(opts.sdcadm, 'opts.sdcadm');
+    assert.func(opts.progress, 'opts.progress');
+    assert.string(opts.image, 'opts.image');
+    assert.optionalBool(opts.dryRun, 'opts.dryRun');
+    assert.optionalString(opts.versionFile, 'opts.versionFile');
+    assert.optionalString(opts.installerDir, 'opts.installerDir');
+    assert.optionalString(opts.wrkDirBase, 'opts.wrkDirBase');
+
+    this.sdcadm = opts.sdcadm;
+    this.log = opts.sdcadm.log;
+    this.progress = opts.progress;
+    this.image = opts.image;
+    this.dryRun = Boolean(opts.dryRun);
+    this.versionFile = opts.versionFile || TRITONADM_VERSION_FILE;
+    this.installerDir = opts.installerDir || INSTALLER_DIR;
+    this.wrkDirBase = opts.wrkDirBase || WRKDIR_BASE;
+}
+
+
+GetTritonadm.prototype.run = function run(cb) {
+    assert.func(cb, 'cb');
+    var self = this;
+    var sdcadm = self.sdcadm;
+    var progress = self.progress;
+    var log = self.log;
+
+    var dryPrefix = self.dryRun ? '[dry-run] ' : '';
+    var unlock;
+    var channel;
+    var installed;
+    var candidate;
+    var installerPath;
+    var wrkDir;
+    var start;
+
+    vasync.pipeline({funcs: [
+        function ensureSdcApp(_, next) {
+            sdcadm.ensureSdcApp({}, next);
+        },
+
+        function getLock(_, next) {
+            if (self.dryRun) {
+                next();
+                return;
+            }
+            sdcadm.acquireLock({progress: progress},
+                    function (lockErr, unlock_) {
+                unlock = unlock_;
+                next(lockErr);
+            });
+        },
+
+        function setStart(_, next) {
+            // After the lock, to avoid wrkDir collisions.
+            start = new Date();
+            next();
+        },
+
+        function getChannel(_, next) {
+            sdcadm.getDefaultChannel(function (err, ch) {
+                channel = ch;
+                progress('Using channel %s', channel);
+                next(err);
+            });
+        },
+
+        function getInstalled(_, next) {
+            readInstalledVersion(self.versionFile,
+                    function (err, vers) {
+                if (err) {
+                    next(err);
+                    return;
+                }
+                installed = vers;
+                if (installed) {
+                    progress('Installed tritonadm: uuid=%s version=%s',
+                        installed.uuid,
+                        installed.version || '<unknown>');
+                } else {
+                    progress('No tritonadm currently installed');
+                }
+                next();
+            });
+        },
+
+        function pickCandidate(_, next) {
+            if (self.image === 'latest') {
+                var filters = {
+                    name: 'tritonadm',
+                    state: 'active'
+                };
+                sdcadm.updates.listImages(filters,
+                        function (err, imgs) {
+                    if (err) {
+                        next(new errors.SDCClientError(err, 'updates'));
+                        return;
+                    }
+                    candidate = pickLatest(imgs);
+                    next();
+                });
+                return;
+            }
+            sdcadm.updates.getImage(self.image, function (err, img) {
+                if (err) {
+                    next(new errors.SDCClientError(err, 'updates'));
+                    return;
+                }
+                candidate = img;
+                next();
+            });
+        },
+
+        function checkCandidate(_, next) {
+            if (!candidate) {
+                progress('No tritonadm images available (using "%s" ' +
+                    'update channel).', channel);
+                next();
+                return;
+            }
+            if (installed && installed.uuid === candidate.uuid) {
+                progress('Already up-to-date (using "%s" update channel).',
+                    channel);
+                candidate = null;
+                next();
+                return;
+            }
+            progress('%sInstall tritonadm %s (%s)', dryPrefix,
+                candidate.version,
+                candidate.uuid);
+            next();
+        },
+
+        function downloadInstaller(_, next) {
+            if (!candidate || self.dryRun) {
+                next();
+                return;
+            }
+            progress('%sDownload tritonadm image from %s', dryPrefix,
+                sdcadm.config.updatesServerUrl);
+            installerPath = self.installerDir + '/tritonadm-' +
+                candidate.uuid;
+            sdcadm.updates.getImageFile(candidate.uuid, installerPath,
+                    function (err) {
+                if (err) {
+                    next(new errors.InternalError({
+                        message: 'error downloading tritonadm image',
+                        updatesServerUrl: sdcadm.config.updatesServerUrl,
+                        uuid: candidate.uuid,
+                        cause: err
+                    }));
+                    return;
+                }
+                fs.chmod(installerPath, 0o755, function (chmodErr) {
+                    if (chmodErr) {
+                        next(new errors.InternalError({
+                            message: 'error chmoding tritonadm installer',
+                            path: installerPath,
+                            cause: chmodErr
+                        }));
+                        return;
+                    }
+                    next();
+                });
+            });
+        },
+
+        function createWrkDir(_, next) {
+            if (!candidate || self.dryRun) {
+                next();
+                return;
+            }
+            var stamp = common.utcTimestamp(start);
+            wrkDir = self.wrkDirBase + '/' + stamp;
+            mkdirp(wrkDir, function (err) {
+                if (err) {
+                    next(new errors.InternalError({
+                        message: 'error creating work dir: ' + wrkDir,
+                        cause: err
+                    }));
+                    return;
+                }
+                next();
+            });
+        },
+
+        function runInstaller(_, next) {
+            if (!candidate) {
+                next();
+                return;
+            }
+            progress('%sRun tritonadm installer (log at %s/install.log)',
+                dryPrefix, wrkDir || '<dry-run>');
+            if (self.dryRun) {
+                next();
+                return;
+            }
+            var cmd = format('%s >%s/install.log 2>&1', installerPath,
+                wrkDir);
+            var env = common.objCopy(process.env);
+            env.TRACE = '1';
+            var execOpts = {env: env};
+            log.trace({cmd: cmd}, 'run tritonadm installer');
+            exec(cmd, execOpts, function (err, stdout, stderr) {
+                log.trace({cmd: cmd, err: err, stdout: stdout,
+                    stderr: stderr}, 'ran tritonadm installer');
+                if (err) {
+                    next(new errors.InternalError({
+                        message: 'error running tritonadm installer',
+                        cmd: cmd,
+                        stdout: stdout,
+                        stderr: stderr,
+                        cause: err
+                    }));
+                    return;
+                }
+                next();
+            });
+        }
+
+    ]}, function finishUp(err) {
+        vasync.pipeline({funcs: [
+            function dropLock(_, next) {
+                if (self.dryRun || !unlock) {
+                    next();
+                    return;
+                }
+                sdcadm.releaseLock({unlock: unlock}, next);
+            },
+            function noteCompletion(_, next) {
+                if (!candidate || err) {
+                    next();
+                    return;
+                }
+                progress('%sInstalled tritonadm %s (%s, elapsed %ss)',
+                    dryPrefix, candidate.version, candidate.uuid,
+                    Math.floor((Date.now() - start) / 1000));
+                next();
+            }
+        ]}, function done(finishErr) {
+            if (finishErr) {
+                log.fatal({err: finishErr},
+                    'unexpected error finishing get-tritonadm');
+            }
+            cb(err || finishErr);
+        });
+    });
+};
+
+
+/**
+ * Download and install tritonadm from the updates channel.
+ * @this Cmdln
+ */
+function do_get_tritonadm(subcmd, opts, args, cb) {
+    var self = this;
+
+    if (opts.help) {
+        self.do_help('help', {}, [subcmd], cb);
+        return;
+    }
+
+    var image = opts.latest ? 'latest' : args.shift();
+    if (!image) {
+        cb(new errors.UsageError(
+            'Please provide an image UUID or use ' +
+            '`sdcadm experimental get-tritonadm --latest`\n' +
+            'in order to install the latest available image.'));
+        return;
+    }
+    if (image === 'help') {
+        cb(new errors.UsageError(
+            'Please use `sdcadm experimental help get-tritonadm` instead'));
+        return;
+    }
+
+    vasync.pipeline({funcs: [
+        function ensureSdcApp(_, next) {
+            self.sdcadm.ensureSdcApp({}, next);
+        },
+        function setServer(_, next) {
+            if (opts.source) {
+                self.sdcadm.config.updatesServerUrl = opts.source;
+            }
+            next();
+        },
+        function setChannel(_, next) {
+            if (opts.channel) {
+                self.sdcadm.updates.channel = opts.channel;
+            }
+            next();
+        },
+        function runEngine(_, next) {
+            var engine = new GetTritonadm({
+                sdcadm: self.sdcadm,
+                progress: self.progress,
+                image: image,
+                dryRun: opts.dry_run
+            });
+            engine.run(next);
+        }
+    ]}, cb);
+}
+
+
+do_get_tritonadm.options = [
+    {
+        names: ['help', 'h'],
+        type: 'bool',
+        help: 'Show this help.'
+    },
+    {
+        names: ['dry-run', 'n'],
+        type: 'bool',
+        help: 'Go through the motions without actually installing.'
+    },
+    {
+        names: ['channel', 'C'],
+        type: 'string',
+        help: 'Use the given channel to fetch the image, even if it is ' +
+            'not the default one.'
+    },
+    {
+        names: ['source', 'S'],
+        type: 'string',
+        help: 'An image source (url) from which to import.'
+    },
+    {
+        names: ['latest'],
+        type: 'bool',
+        help: 'Get the latest available image.'
+    }
+];
+
+
+do_get_tritonadm.help = (
+    'Download and install tritonadm from the updates channel.\n' +
+    '\n' +
+    'This is an experimental command. It fetches a tritonadm image\n' +
+    'and executes its self-extracting installer. When the candidate\n' +
+    'image UUID matches the uuid recorded in\n' +
+    '/opt/triton/tritonadm/etc/version, the command short-circuits\n' +
+    'with "Already up-to-date".\n' +
+    '\n' +
+    'Usage:\n' +
+    '     # Install the given image UUID:\n' +
+    '     {{name}} get-tritonadm IMAGE_UUID [<options>]\n' +
+    '     # Install the latest available image:\n' +
+    '     {{name}} get-tritonadm --latest [<options>]\n' +
+    '     # Install from a specific imgapi server:\n' +
+    '     {{name}} get-tritonadm -S http://imgapi.example.com IMAGE_UUID\n' +
+    '\n' +
+    '{{options}}'
+);
+
+do_get_tritonadm.logToFile = true;
+
+
+// --- exports
+
+module.exports = {
+    do_get_tritonadm: do_get_tritonadm,
+    _GetTritonadm: GetTritonadm,
+    _parseVersionFile: parseVersionFile,
+    _readInstalledVersion: readInstalledVersion,
+    _pickLatest: pickLatest,
+    _TRITONADM_VERSION_FILE: TRITONADM_VERSION_FILE
+};

--- a/lib/cli/experimental.js
+++ b/lib/cli/experimental.js
@@ -94,6 +94,9 @@ require('./do_nfs_volumes').do_nfs_volumes;
 
 ExperimentalCLI.prototype.do_remove_ca = require('./do_remove_ca').do_remove_ca;
 
+ExperimentalCLI.prototype.do_get_tritonadm =
+require('./do_get_tritonadm').do_get_tritonadm;
+
 // --- exports
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sdcadm",
   "description": "Administer a Triton Data Center",
-  "version": "1.39.1",
+  "version": "1.39.2",
   "author": "Edgecast Cloud (edgecast.io)",
   "private": true,
   "dependencies": {

--- a/test/get-tritonadm.test.js
+++ b/test/get-tritonadm.test.js
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2026 Edgecast Cloud LLC.
+ */
+
+/*
+ * NB: these tests require a tritonadm image to be published on the
+ * updates server's selected channel.
+ */
+
+var test = require('tape').test;
+var exec = require('child_process').exec;
+
+
+function checkGetResults(t, err, stdout, stderr, moreStrings) {
+    t.ifError(err);
+    t.equal(stderr, '');
+
+    if (stdout.indexOf('Already up-to-date') !== -1 ||
+            stdout.indexOf('No tritonadm images available') !== -1) {
+        t.end();
+        return;
+    }
+
+    var findStrings = [
+        'Install tritonadm',
+        'Download tritonadm image from',
+        'Run tritonadm installer'
+    ];
+
+    if (moreStrings) {
+        findStrings = findStrings.concat(moreStrings);
+    }
+
+    findStrings.forEach(function (str) {
+        t.ok(stdout.match(str), 'check ' + str + ' present in output');
+    });
+
+    t.end();
+}
+
+
+test('sdcadm experimental get-tritonadm --help', function (t) {
+    exec('sdcadm experimental get-tritonadm --help',
+            function (err, stdout, stderr) {
+        t.ifError(err);
+        t.notEqual(stdout.indexOf(
+            'experimental get-tritonadm --latest [<options>]'),
+            -1);
+        t.equal(stderr, '');
+        t.end();
+    });
+});
+
+
+test('sdcadm experimental get-tritonadm (no args) errors', function (t) {
+    exec('sdcadm experimental get-tritonadm',
+            function (err, _stdout, stderr) {
+        t.ok(err, 'expected error exit when called without arguments');
+        t.ok(stderr.match(/image UUID|--latest/i),
+            'error mentions required arg');
+        t.end();
+    });
+});
+
+
+test('sdcadm experimental get-tritonadm --latest --dry-run', function (t) {
+    exec('sdcadm experimental get-tritonadm --latest --dry-run',
+            function (err, stdout, stderr) {
+        checkGetResults(t, err, stdout, stderr);
+    });
+});
+
+
+test('sdcadm experimental get-tritonadm --latest --channel=staging',
+        function (t) {
+    var cmd = 'sdcadm experimental get-tritonadm --latest --dry-run ' +
+        '--channel=staging';
+    exec(cmd, function (err, stdout, stderr) {
+        checkGetResults(t, err, stdout, stderr, ['Using channel staging']);
+    });
+});

--- a/test/unit/cli/do_get_tritonadm.test.js
+++ b/test/unit/cli/do_get_tritonadm.test.js
@@ -1,0 +1,265 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright 2026 Edgecast Cloud LLC.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tap = require('tap');
+
+const testutil = require('../testutil');
+
+const do_get_tritonadm = require('../../../lib/cli/do_get_tritonadm');
+const parseVersionFile = do_get_tritonadm._parseVersionFile;
+const readInstalledVersion = do_get_tritonadm._readInstalledVersion;
+const pickLatest = do_get_tritonadm._pickLatest;
+const GetTritonadm = do_get_tritonadm._GetTritonadm;
+
+
+function tmpdir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'tritonadm-test-'));
+}
+
+
+tap.test('parseVersionFile: all fields', function (t) {
+    var content = [
+        'uuid=11111111-2222-3333-4444-555555555555',
+        'version=master-20260420T120000Z-gabcdef1',
+        'installed_at=2026-04-20T12:00:00Z',
+        'source=network'
+    ].join('\n');
+    var parsed = parseVersionFile(content);
+    t.equal(parsed.uuid, '11111111-2222-3333-4444-555555555555');
+    t.equal(parsed.version, 'master-20260420T120000Z-gabcdef1');
+    t.equal(parsed.installed_at, '2026-04-20T12:00:00Z');
+    t.equal(parsed.source, 'network');
+    t.end();
+});
+
+
+tap.test('parseVersionFile: ignores blank lines and comments', function (t) {
+    var content = [
+        '# a comment',
+        '',
+        '   ',
+        'uuid=abc',
+        '# trailing',
+        'source=embedded'
+    ].join('\n');
+    var parsed = parseVersionFile(content);
+    t.equal(parsed.uuid, 'abc');
+    t.equal(parsed.source, 'embedded');
+    t.notOk(parsed['# a comment']);
+    t.end();
+});
+
+
+tap.test('parseVersionFile: values containing =', function (t) {
+    var parsed = parseVersionFile('foo=bar=baz');
+    t.equal(parsed.foo, 'bar=baz');
+    t.end();
+});
+
+
+tap.test('parseVersionFile: trims whitespace', function (t) {
+    var parsed = parseVersionFile('  uuid  =  abc  \n');
+    t.equal(parsed.uuid, 'abc');
+    t.end();
+});
+
+
+tap.test('parseVersionFile: skips lines with no =', function (t) {
+    var parsed = parseVersionFile('nothere\nuuid=abc\n');
+    t.equal(parsed.uuid, 'abc');
+    t.notOk(parsed.nothere);
+    t.end();
+});
+
+
+tap.test('readInstalledVersion: happy path', function (t) {
+    var dir = tmpdir();
+    var filePath = path.join(dir, 'version');
+    fs.writeFileSync(filePath,
+        'uuid=11111111-2222-3333-4444-555555555555\n' +
+        'version=master-20260420T120000Z-gabcdef1\n' +
+        'installed_at=2026-04-20T12:00:00Z\n' +
+        'source=network\n');
+    t.teardown(function () {
+        fs.unlinkSync(filePath);
+        fs.rmdirSync(dir);
+    });
+    readInstalledVersion(filePath, function (err, vers) {
+        t.error(err);
+        t.ok(vers);
+        t.equal(vers.uuid, '11111111-2222-3333-4444-555555555555');
+        t.equal(vers.source, 'network');
+        t.end();
+    });
+});
+
+
+tap.test('readInstalledVersion: missing file returns null', function (t) {
+    var dir = tmpdir();
+    var filePath = path.join(dir, 'version');
+    t.teardown(function () { fs.rmdirSync(dir); });
+    readInstalledVersion(filePath, function (err, vers) {
+        t.error(err);
+        t.equal(vers, null);
+        t.end();
+    });
+});
+
+
+tap.test('readInstalledVersion: file without uuid returns null',
+        function (t) {
+    var dir = tmpdir();
+    var filePath = path.join(dir, 'version');
+    fs.writeFileSync(filePath, '# no uuid here\nsource=network\n');
+    t.teardown(function () {
+        fs.unlinkSync(filePath);
+        fs.rmdirSync(dir);
+    });
+    readInstalledVersion(filePath, function (err, vers) {
+        t.error(err);
+        t.equal(vers, null);
+        t.end();
+    });
+});
+
+
+tap.test('pickLatest: empty array', function (t) {
+    t.equal(pickLatest([]), undefined);
+    t.end();
+});
+
+
+tap.test('pickLatest: sorts descending by published_at', function (t) {
+    var a = {uuid: 'a', published_at: '2026-01-01T00:00:00Z'};
+    var b = {uuid: 'b', published_at: '2026-04-01T00:00:00Z'};
+    var c = {uuid: 'c', published_at: '2026-02-01T00:00:00Z'};
+    t.equal(pickLatest([a, b, c]).uuid, 'b');
+    t.end();
+});
+
+
+/*
+ * When the installed uuid matches the candidate uuid, the engine must
+ * not call getImageFile.
+ */
+tap.test('GetTritonadm: UUID match short-circuits before download',
+        function (t) {
+    var dir = tmpdir();
+    var versionFile = path.join(dir, 'version');
+    fs.writeFileSync(versionFile,
+        'uuid=11111111-2222-3333-4444-555555555555\n' +
+        'version=master-20260420T120000Z-gabcdef1\n');
+    t.teardown(function () {
+        fs.unlinkSync(versionFile);
+        fs.rmdirSync(dir);
+    });
+
+    var downloadCalled = false;
+    var stubSdcadm = {
+        log: testutil.createBunyanLogger(tap),
+        config: {updatesServerUrl: 'http://example.invalid'},
+        ensureSdcApp: function (_opts, cb) { cb(); },
+        acquireLock: function (_opts, cb) {
+            cb(null, function unlock(unlockCb) { unlockCb(); });
+        },
+        releaseLock: function (opts, cb) { opts.unlock(cb); },
+        getDefaultChannel: function (cb) { cb(null, 'staging'); },
+        updates: {
+            listImages: function (_filters, cb) {
+                cb(null, [{
+                    uuid: '11111111-2222-3333-4444-555555555555',
+                    name: 'tritonadm',
+                    version: 'master-20260420T120000Z-gabcdef1',
+                    published_at: '2026-04-20T12:00:00Z'
+                }]);
+            },
+            getImage: function (_uuid, cb) {
+                cb(new Error('getImage should not be called'));
+            },
+            getImageFile: function (_uuid, _filePath, cb) {
+                downloadCalled = true;
+                cb(new Error('download should not be called'));
+            }
+        }
+    };
+
+    var messages = [];
+    var engine = new GetTritonadm({
+        sdcadm: stubSdcadm,
+        progress: function () {
+            messages.push(require('util').format.apply(null, arguments));
+        },
+        image: 'latest',
+        versionFile: versionFile
+    });
+
+    engine.run(function (err) {
+        t.error(err);
+        t.equal(downloadCalled, false,
+            'getImageFile must not be called when UUIDs match');
+        t.match(messages.join('\n'), /Already up-to-date/);
+        t.end();
+    });
+});
+
+
+/*
+ * Empty channel: no download, friendly message.
+ */
+tap.test('GetTritonadm: empty channel reports nothing to install',
+        function (t) {
+    var dir = tmpdir();
+    var versionFile = path.join(dir, 'does-not-exist');
+    t.teardown(function () { fs.rmdirSync(dir); });
+
+    var downloadCalled = false;
+    var stubSdcadm = {
+        log: testutil.createBunyanLogger(tap),
+        config: {updatesServerUrl: 'http://example.invalid'},
+        ensureSdcApp: function (_opts, cb) { cb(); },
+        acquireLock: function (_opts, cb) {
+            cb(null, function unlock(unlockCb) { unlockCb(); });
+        },
+        releaseLock: function (opts, cb) { opts.unlock(cb); },
+        getDefaultChannel: function (cb) { cb(null, 'staging'); },
+        updates: {
+            listImages: function (_filters, cb) { cb(null, []); },
+            getImage: function (_uuid, cb) {
+                cb(new Error('getImage should not be called'));
+            },
+            getImageFile: function (_uuid, _filePath, cb) {
+                downloadCalled = true;
+                cb(new Error('download should not be called'));
+            }
+        }
+    };
+
+    var messages = [];
+    var engine = new GetTritonadm({
+        sdcadm: stubSdcadm,
+        progress: function () {
+            messages.push(require('util').format.apply(null, arguments));
+        },
+        image: 'latest',
+        versionFile: versionFile
+    });
+
+    engine.run(function (err) {
+        t.error(err);
+        t.equal(downloadCalled, false);
+        t.match(messages.join('\n'), /No tritonadm images available/);
+        t.end();
+    });
+});


### PR DESCRIPTION
```
Portions generated with: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Reviewed by: Travis Paul <tpaul@edgecast.io>
```

Downloads and installs the tritonadm companion tool from the updates channel and short-circuits with "Already up-to-date" when the candidate image UUID matches the uuid recorded in
/opt/triton/tritonadm/etc/version (KEY=VALUE format written by tritonadm's own install.sh).